### PR TITLE
fix(release): support immutable UI releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "SemVer release tag (for example, v0.1.1)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -13,12 +19,42 @@ jobs:
     name: goreleaser
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # GoReleaser needs full history for changelog generation.
           fetch-depth: 0
           persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.ref }}
+
+      - name: validate release tag
+        shell: bash
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Release tag must be semantic version prefixed with v."
+            exit 1
+          fi
+
+      - name: create release tag
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          commit="$(git rev-parse HEAD)"
+          if tag_commit="$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}" 2>/dev/null)"; then
+            if [[ "$tag_commit" != "$commit" ]]; then
+              echo "::error::Tag $RELEASE_TAG already points to another commit."
+              exit 1
+            fi
+          else
+            gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f ref="refs/tags/$RELEASE_TAG" \
+              -f sha="$commit"
+            git tag "$RELEASE_TAG" "$commit"
+          fi
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -27,7 +63,7 @@ jobs:
 
       - name: verify tag is reachable from main
         run: |
-          tag_commit="$(git rev-list -n 1 "$GITHUB_REF")"
+          tag_commit="$(git rev-list -n 1 "$RELEASE_TAG")"
           if ! git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main; then
             echo "::error::Release tag must point to a commit reachable from origin/main."
             exit 1


### PR DESCRIPTION
## Summary
- add a manual Actions trigger that accepts a SemVer release tag
- create the tag from `main` before running the existing release checks and GoReleaser
- preserve the existing tag-push release path

This lets GoReleaser create a draft, upload all assets, and publish only after upload, which is required when immutable releases are enabled.

## Verification
- `git diff --check`
- reviewed both tag-push and manual-dispatch paths

## Recovery
After merge, run the `release` workflow from `main` with tag `v0.1.1`. Do not create the GitHub release manually first.