### PR TITLE
fix(redact): mask URL userinfo passwords and bearer credentials

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -246,7 +246,11 @@ numbat writes typed NDJSON streams. Each record carries a `record_type` (`event`
 `endpoint.device_id` for fleet joins.
 `enforcement` is hook-only; `scan_summary` is scan-only.
 
-Event and finding value fields are redacted before emission. Event/timeline
+Event and finding value fields are redacted before emission. Masking covers
+credential-bearing URL query values, secret-like assignments, self-identifying
+token formats, a URL userinfo password (emitted as
+`postgres://user:%5Bredacted%5D@host:5432/db`, percent-encoded so the URL still
+parses), and an `Authorization: Bearer` credential. Event/timeline
 output keeps a readable, redacted `project_path`; findings and indicators use
 `project_path_hash` / `sample_project_path_hash` for joins. On findings,
 `redacted:true` means at least one emitted finding field was masked. File-backed

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -28,6 +28,41 @@ var tokenPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`-----BEGIN [A-Z ]*PRIVATE KEY-----`),
 }
 
+// authorizationBearerPattern matches an RFC 6750 bearer credential in the
+// Authorization header position: the literal header name, an optional
+// JSON/YAML quote and ':'/'=' operator, the literal Bearer scheme, then the
+// credential. Group 1 is the header and scheme text and is preserved; group 2 is
+// the credential and is masked, so an observed request stays readable.
+//
+// Precision boundaries, each chosen to keep this anchored rather than fuzzy:
+//   - The header anchor is REQUIRED. RFC 6750 defines the scheme only for this
+//     header, so a floating "Bearer" word in prose, a log message, or an
+//     identifier is not a credential context and masking after it would be a
+//     pure false positive. Matching is case-insensitive (HTTP header names are)
+//     and unanchored on the left, which also covers Proxy-Authorization. The
+//     header name must be followed directly by the operator, so a subscript or
+//     call form (headers["Authorization"] = "Bearer …") is an accepted false
+//     negative: admitting one such spelling invites every other quoting and
+//     accessor syntax, with no principled place to stop.
+//   - The credential charset is b64token plus its optional '=' padding, so a
+//     shell placeholder such as `Bearer $TOKEN` or a doc placeholder such as
+//     `Bearer <token>` stays readable.
+//   - 8 bytes is the minimum credential length. It sits above every short
+//     synthetic placeholder ("test", "tok123", "secret" — 4 to 6 bytes) that
+//     appears in fixtures and documentation, and below the shortest real token
+//     this pass exists to catch. A genuine token under 8 bytes is an accepted
+//     false negative. NOTE the length gate is the ONLY filter on the credential:
+//     the header anchor is trusted, so a word of prose that follows it ("…the
+//     Authorization: Bearer credential must be rotated") is masked too. That is
+//     an accepted over-mask — the alternative is entropy or dictionary guessing,
+//     which is neither deterministic nor explainable — and the anchor keeps it
+//     confined to text that already claims to be an Authorization header.
+//   - The separator is SP/HTAB only, not any whitespace. Content previews are
+//     multi-line, so crossing a newline would mask the next line's first word;
+//     an obs-folded header is therefore an accepted false negative.
+var authorizationBearerPattern = regexp.MustCompile(
+	`(?i)(authorization["']?[ \t]*[:=][ \t]*["']?bearer[ \t]+)([A-Za-z0-9._~+/-]{8,}={0,2})`)
+
 // secretKey matches a secret-looking assignment key (env var, JSON field,
 // YAML key). Capture group 1 is the key text as written.
 const secretKey = `([A-Za-z0-9_."'-]*(?i:SECRET|TOKEN|PASSWORD|PASSWD|API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY)[A-Za-z0-9_."'-]*)`
@@ -64,12 +99,19 @@ var credentialQueryKeys = map[string]struct{}{
 
 const maxCredentialQueryKeyLen = len("x-amz-security-token")
 
-// String masks exact credential parameters, secret-like assignments, and
-// self-identifying token formats. Credential-key matching uses a normalized
-// whole-input view rather than trusting URL boundaries; the broader assignment
-// patterns are limited to non-URL spans to avoid masking benign query keys such
-// as id_token.
+// String masks exact credential parameters, credentials held in a fixed
+// grammatical position (a URL userinfo password, an Authorization: Bearer
+// credential), secret-like assignments, and self-identifying token formats.
+// Credential-key matching uses a normalized whole-input view rather than
+// trusting URL boundaries; the broader assignment patterns are limited to
+// non-URL spans to avoid masking benign query keys such as id_token.
+//
+// The position-driven passes run first: they delimit their own credential span
+// exactly, so masking there leaves less ambiguous text for the later, broader
+// passes to interpret.
 func String(s string) string {
+	s = maskURLUserinfoPasswords(s)
+	s = maskAuthorizationBearer(s)
 	s = maskCredentialValues(s)
 	var b strings.Builder
 	last := 0
@@ -376,6 +418,146 @@ func valueEnd(s string, start int) int {
 		i++
 	}
 	return i
+}
+
+// urlSchemePattern matches an RFC 3986 scheme followed by "//": the start of a
+// URL authority. It deliberately accepts ANY scheme rather than just http(s),
+// because an embedded password is overwhelmingly a database or broker DSN
+// (postgres://, redis://, amqp://, mongodb+srv://), and a defanged scheme
+// (hxxp://) must still be recognized. It only locates a candidate authority;
+// maskURLUserinfoPasswords decides what to mask. Note this is NOT urlPattern:
+// widening that pattern would extend the region where the assignment pass is
+// suppressed, which changes unrelated behavior.
+var urlSchemePattern = regexp.MustCompile(`[A-Za-z][A-Za-z0-9+.-]*://`)
+
+// userinfoMask replaces a URL password in place. It is Mask with its brackets
+// percent-encoded, because the emitted URL must remain parseable: downstream
+// consumers strip userinfo structurally with net/url, and a raw "[redacted]" is
+// invalid userinfo, so it would fail that parse and drop the whole URL — host and
+// path included — rather than just the credential.
+const userinfoMask = "%5Bredacted%5D"
+
+// maskURLUserinfoPasswords masks the password of a URL authority
+// (scheme://user:password@host). The credential is identified by its POSITION in
+// the RFC 3986 grammar, not by a secret-looking key name, which is what closes
+// the DSN leak class (postgres://user:p4ssw0rd@host/db): no query key, no
+// assignment key, and no self-describing shape is present for the other passes
+// to match. The username, host, port, and path are left intact by THIS pass —
+// they carry triage value and are not credentials. (A username that is itself
+// secret-looking, as in postgres://token:pw@host/db, is still masked by the later
+// assignment pass, which takes the rest of the URL with it.)
+//
+// Span boundaries — both are load-bearing, and TestStringMasksURLUserinfoPassword
+// asserts exact output because a substring check cannot tell them apart:
+//   - The userinfo ends at the LAST '@' inside the authority, so neither a
+//     password containing '@' nor a later '@' in the path or query can leave a
+//     surviving credential tail.
+//   - The password starts at the FIRST ':' of the userinfo, so a password
+//     containing ':' is masked whole.
+//
+// Not masked, by design:
+//   - A userinfo with no ':' (scheme://token@host): a bare username is normally
+//     not a credential, and a self-describing token there is already caught by
+//     tokenPatterns. An empty password (scheme://user:@host) has nothing to leak.
+//   - A userinfo holding a byte that ends the authority scan — an unencoded '/',
+//     whitespace, a non-ASCII byte, a quote, or one of the list separators in
+//     authorityTerminator. This covers the USERNAME as well as the password: the
+//     scan stops before it ever reaches the '@', so postgres://usér:pw@h/db is
+//     left alone even though the password itself is maskable. The scan then finds
+//     no '@' and masks nothing, so every case here is a false negative rather
+//     than a partial mask, and each class is recorded in
+//     TestStringKnownFalseNegatives. Widening the scan to recover them was
+//     measured to be worse: it reads a benign path such as /download/file@2x.png
+//     as userinfo and masks the path, and running through non-ASCII text lets a
+//     CJK sentence bridge a host:port to an address later in the line.
+func maskURLUserinfoPasswords(s string) string {
+	var b strings.Builder
+	last := 0
+	for _, loc := range urlSchemePattern.FindAllStringIndex(s, -1) {
+		authStart := loc[1]
+		// Matches arrive in increasing order and authorityEnd stops at the '/'
+		// that any later scheme match must contain, so spans cannot overlap and
+		// this cannot fire today. It stays because the splice below indexes
+		// s[last:pwStart]: were that invariant ever broken, the alternative to
+		// skipping is a panic on a redaction path.
+		if authStart < last {
+			continue
+		}
+		at := strings.LastIndexByte(s[authStart:authorityEnd(s, authStart)], '@')
+		if at < 0 {
+			continue
+		}
+		colon := strings.IndexByte(s[authStart:authStart+at], ':')
+		if colon < 0 {
+			continue
+		}
+		pwStart, pwEnd := authStart+colon+1, authStart+at
+		if pwStart >= pwEnd {
+			continue
+		}
+		if last == 0 {
+			b.Grow(len(s) + len(userinfoMask))
+		}
+		b.WriteString(s[last:pwStart])
+		b.WriteString(userinfoMask)
+		last = pwEnd
+	}
+	if last == 0 {
+		return s
+	}
+	b.WriteString(s[last:])
+	return b.String()
+}
+
+// authorityEnd returns the index one past the URL authority beginning at start.
+// The scan is deliberately short rather than greedy, because every byte it reads
+// past the real host is a byte that can turn an unrelated '@' later in the line
+// into a fabricated userinfo — masking a port as a password, destroying two true
+// indicators and inventing a third. It therefore stops at:
+//
+//   - '/', '?', '#' — where RFC 3986 ends the authority.
+//   - Whitespace, control bytes, the quote/brace/pipe wrappers, and every
+//     non-ASCII byte, none of which may appear in a URI at all. A URI is ASCII,
+//     so a byte >= 0x80 is the text AROUND the URL — CJK or other non-English
+//     prose, a no-break space pasted from a page, typographic punctuation — and
+//     treating it as authority-legal is how a CJK sentence bridges a benign
+//     host:port to an address later in the line. Stopping at a wrapper also keeps
+//     the scan inside one quoted string, so a JSON value like "redis://u:p"
+//     followed by a later field containing '@' is not read as a single authority.
+//   - ',' ';' '&' '(' ')' — legal userinfo sub-delims, but in practice they
+//     separate items in a list, a query, or a CSV row and wrap a markdown link.
+//     Reading past one is exactly how "https://api.test:8443;user=ops@corp.test"
+//     becomes a false positive, so precision wins here.
+//
+// The cost is a false negative when a password contains one of those bytes
+// unencoded (RFC 3986 requires percent-encoding for all of them except the five
+// sub-delims); see maskURLUserinfoPasswords and TestStringKnownFalseNegatives.
+func authorityEnd(s string, start int) int {
+	i := start
+	for i < len(s) && !authorityTerminator(s[i]) {
+		i++
+	}
+	return i
+}
+
+// authorityTerminator reports whether b ends an authority scan. '[' and ']' are
+// deliberately absent so an IPv6 literal host stays inside the scan.
+func authorityTerminator(b byte) bool {
+	switch b {
+	case '/', '?', '#',
+		'"', '\'', '`', '<', '>', '\\', '{', '}', '|', '^',
+		',', ';', '&', '(', ')':
+		return true
+	}
+	// Space, every control byte, and every non-ASCII byte (DEL upward).
+	return b <= ' ' || b >= 0x7F
+}
+
+// maskAuthorizationBearer masks the credential of an Authorization: Bearer
+// header, keeping the header name and scheme so the observed request stays
+// readable. See authorizationBearerPattern for the precision boundaries.
+func maskAuthorizationBearer(s string) string {
+	return authorizationBearerPattern.ReplaceAllString(s, "${1}"+Mask)
 }
 
 // maskAssignAll runs every assignment pass over s, masking KEY=VALUE secret

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,6 +1,8 @@
 package redact
 
 import (
+	// Aliased: two tests below use "url" as a local variable for the URL under test.
+	neturl "net/url"
 	"strings"
 	"testing"
 )
@@ -89,16 +91,227 @@ func TestStringLeavesBenignText(t *testing.T) {
 // TestStringKnownFalseNegatives documents secret shapes redaction does NOT
 // catch today. These assertions lock current behavior so a future redaction
 // change that starts (or stops) catching them is an intentional, reviewed edit.
+//
+// The bare AWS secret access key is an ACCEPTED PERMANENT gap, not a backlog
+// item. It is 40 arbitrary base64 bytes with no prefix, no key name, and no
+// grammatical position to anchor on — unlike the userinfo password and the
+// bearer credential, which are anchored by RFC 3986 and RFC 6750 syntax
+// respectively and are masked (see TestStringMasksURLUserinfoPassword and
+// TestStringMasksAuthorizationBearer). The only pattern that would catch it is a
+// generic 40-char shape, which would also mask hashes, git object ids, and
+// random identifiers in benign command output. CONTRIBUTING.md requires
+// preferring a documented false negative to a false positive, so it stays here.
+//
+// The userinfo entries are the boundary of the userinfo pass, in the same
+// tradition: a userinfo holding a byte that ends the authority scan (an unencoded
+// '/', whitespace, a non-ASCII byte, or a list separator — see
+// authorityTerminator) abandons the match rather than masking part of it. That
+// includes a byte in the USERNAME, which strands an otherwise maskable password.
+// Widening the scan to reach these was measured to be worse: it reads a benign
+// path such as /download/file@2x.png as userinfo, and running it through
+// non-ASCII text lets a CJK sentence bridge a host:port to an unrelated address
+// (see TestStringPreservesURLWithoutUserinfoPassword).
+//
+// RFC 3986 requires percent-encoding for the '/' and whitespace and non-ASCII
+// spellings, and those percent-encoded forms ARE masked — see the
+// "percent-encoded slash" case in TestStringMasksURLUserinfoPassword. The list
+// separators are the exception: they are legal sub-delims, so a password
+// containing one is a deliberate precision trade, not a malformed URL.
+//
+// The assertion is exact equality, not containment: each entry locks the whole
+// line, so a change that starts masking anything else on it is caught too.
 func TestStringKnownFalseNegatives(t *testing.T) {
 	cases := []string{
-		"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", // bare AWS secret access key, no key= prefix
-		"postgres://user:p4ssw0rd@host:5432/db",    // DB-URL embedded password
-		"Authorization: Bearer abcdef123456",       // bearer token without a secret-looking key
+		"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",                              // bare AWS secret access key, no key= prefix
+		"postgres://svc:S3cret/Key+9@db.test:5432/app",                          // '/' ends the authority scan before the '@'
+		"postgres://user:wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY@host:5432/db", // same, with the AWS key as the password
+		"postgres://user:SUPER retPW42@host:5432/db",                            // whitespace ends the authority scan
+		"postgres://user:p,ss@db.test/app",                                      // ',' is read as a list separator, not a password byte
+		"postgres://user:pässwörd@db.test/app",                                  // non-ASCII cannot appear in a URI at all
+		"postgres://usér:S3cretPw@db.test/app",                                  // non-ASCII in the USERNAME strands a maskable password
+		`headers["Authorization"] = "Bearer S3CRETVALUE1234"`,                   // subscript form: ']' separates the header name from the operator
 	}
 	for _, c := range cases {
-		if got := String(c); !strings.Contains(got, c) {
+		if got := String(c); got != c {
 			t.Fatalf("behavior changed (now masked) for known false negative %q -> %q", c, got)
 		}
+	}
+}
+
+// TestStringMasksURLUserinfoPassword covers the DSN leak class: a password in the
+// URL authority is a live credential, positionally identified by RFC 3986 rather
+// than by a secret-looking key, so it is masked for any scheme. The scheme,
+// username, host, port, and path stay readable so the observation is still
+// actionable.
+//
+// The assertion is EXACT output, not "the secret is absent". The masked span is
+// defined by two rules — it starts at the first ':' of the userinfo and ends at
+// the last '@' of the authority — and a substring check cannot distinguish them
+// from first-'@'/last-':' variants that leak the password's head or tail: with
+// "p@ss" masked as "%5Bredacted%5D@ss", the substring "p@ss" is absent from a
+// string that still leaks "ss".
+func TestStringMasksURLUserinfoPassword(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"postgres dsn", "postgres://user:p4ssw0rd@host:5432/db", "postgres://user:" + userinfoMask + "@host:5432/db"},
+		{"https userinfo", "https://user:hunter2@example.test/x", "https://user:" + userinfoMask + "@example.test/x"},
+		{"password with colon", "redis://u:pa:ss@cache.test:6379/0", "redis://u:" + userinfoMask + "@cache.test:6379/0"},
+		{"password with at", "amqp://u:p@ss@broker.test/vhost", "amqp://u:" + userinfoMask + "@broker.test/vhost"},
+		{"empty username", "redis://:pw123456@cache.test:6379/0", "redis://:" + userinfoMask + "@cache.test:6379/0"},
+		{"srv scheme", "mongodb+srv://admin:s3cr3t@cluster.test/admin", "mongodb+srv://admin:" + userinfoMask + "@cluster.test/admin"},
+		{"ipv6 host", "https://user:hunter2@[2001:db8::1]:8443/x", "https://user:" + userinfoMask + "@[2001:db8::1]:8443/x"},
+		{"defanged scheme", "hxxp://user:hunter2@evil.test/x", "hxxp://user:" + userinfoMask + "@evil.test/x"},
+		{"percent-encoded slash", "postgres://user:S3cret%2FKey@db.test/app", "postgres://user:" + userinfoMask + "@db.test/app"},
+		{"inside prose", "connecting to postgres://user:topsecret@db.test/app now", "connecting to postgres://user:" + userinfoMask + "@db.test/app now"},
+		{
+			"two dsns on one line",
+			"postgres://a:pw1@x.test/d redis://b:pw2@y.test/0",
+			"postgres://a:" + userinfoMask + "@x.test/d redis://b:" + userinfoMask + "@y.test/0",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := String(c.in); got != c.want {
+				t.Fatalf("String(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestStringPreservesURLWithoutUserinfoPassword is the anti-over-redaction guard
+// for the userinfo pass: a ':' or '@' that is not a userinfo password separator
+// must leave the text byte-identical.
+//
+// The second group is the reason authorityEnd stops at a list separator. Each of
+// those lines pairs a benign host:port with an unrelated '@' later on; a greedier
+// authority scan reads the two as one authority and masks the PORT as a password,
+// which destroys two real indicators (the host and the email) and fabricates a
+// third from the text after the '@' — the exact failure the "no fabrication" half
+// of the CONTRIBUTING.md precision contract forbids.
+func TestStringPreservesURLWithoutUserinfoPassword(t *testing.T) {
+	cases := []string{
+		"https://host.test:8443/path",                    // host:port, no userinfo at all
+		"postgres://user@db.test:5432/app",               // colon-less userinfo stays readable
+		"https://user:@host.test/x",                      // empty password, nothing to leak
+		"https://[2001:db8::1]:8443/x",                   // IPv6 literal host, colons but no userinfo
+		"git@github.com:org/repo.git",                    // scp-style remote, not a URL authority
+		"https://x.test/p?email=alice%40corp.test",       // '@' lives in the query
+		`{"url":"redis://u:p","note":"a@b.test"}`,        // '@' is in a LATER quoted field
+		"run docker://image:tag then mail bob@corp.test", // ':' and '@' in separate tokens
+
+		"upstream=https://api.test:8443;user=ops@corp.test",                 // ';' separated pairs
+		"api.test,https://api.test:8443,ops@corp.test",                      // CSV row
+		"https://[2001:db8::1]:8443,admin@corp.test",                        // CSV row, IPv6 host
+		"--url https://h.test:8443&mail=ops@corp.test",                      // '&' separated pairs
+		"[api](https://h.test:8443)[mail](mailto:ops@corp.test)",            // adjacent markdown links
+		"[api](https://h.test:8443)ops@corp.test",                           // ')' is the only separator
+		"https://h.test:8443(ops@corp.test)",                                // '(' is the only separator
+		"docker run -e URL=redis://cache.test:6379,ADMIN=ops@corp.test img", // env list
+
+		// A URI is ASCII, so any byte >= 0x80 is text around the URL. CJK prose has
+		// no spaces to stop the scan, and a no-break space or an em dash reads as an
+		// ordinary byte, so each of these would otherwise mask the PORT as a
+		// password and invent a host from the address that follows.
+		"https://api.test:8443 ops@corp.test",          // no-break space
+		"サーバhttps://api.test:8443へ接続、管理者ops@corp.test", // CJK prose, no ASCII whitespace at all
+		"https://h.test:8443—ops@corp.test",            // em dash
+		"https://[2001:db8::1]:8443 admin@corp.test",   // no-break space, IPv6 host
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			if got := String(in); got != in {
+				t.Fatalf("URL over-redacted: %q -> %q", in, got)
+			}
+		})
+	}
+}
+
+// TestStringMasksURLUserinfoKeepsURLParseable locks the reason userinfoMask is
+// percent-encoded instead of the raw Mask. Downstream consumers strip userinfo
+// structurally with net/url; a raw "[redacted]" is invalid userinfo, so it would
+// fail that parse and drop the host and path along with the credential, turning a
+// redaction into lost signal.
+func TestStringMasksURLUserinfoKeepsURLParseable(t *testing.T) {
+	got := String("https://user:secretpw123@evil.example/x")
+	u, err := neturl.Parse(got)
+	if err != nil {
+		t.Fatalf("redacted URL no longer parses: %q: %v", got, err)
+	}
+	u.User = nil
+	if want := "https://evil.example/x"; u.String() != want {
+		t.Fatalf("userinfo strip = %q, want %q (from %q)", u.String(), want, got)
+	}
+}
+
+// TestStringMasksAuthorizationBearer covers the RFC 6750 leak class: the
+// credential is anchored by the Authorization header position, not by a
+// secret-looking key, so the header name and the Bearer scheme are preserved
+// while the credential is masked.
+func TestStringMasksAuthorizationBearer(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"header", "Authorization: Bearer abcdef123456", "Authorization: Bearer " + Mask},
+		{"lowercase", "authorization: bearer abcdef123456", "authorization: bearer " + Mask},
+		{"json", `{"Authorization":"Bearer abcdef123456"}`, `{"Authorization":"Bearer ` + Mask + `"}`},
+		{"proxy header", "Proxy-Authorization: Bearer abcdef123456", "Proxy-Authorization: Bearer " + Mask},
+		{"tab separated", "Authorization:\tBearer abcdef123456", "Authorization:\tBearer " + Mask},
+		{"equals operator", "Authorization=Bearer abcdef123456", "Authorization=Bearer " + Mask},
+		{
+			"jwt",
+			"Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.c2lnbmF0dXJl",
+			"Authorization: Bearer " + Mask,
+		},
+		{"base64 padding", "Authorization: Bearer YWJjZGVmZ2hpams=", "Authorization: Bearer " + Mask},
+		// 8 bytes is the exact length gate; the 7-byte form is in the preserve test.
+		{"minimum length", "Authorization: Bearer abcd1234", "Authorization: Bearer " + Mask},
+		{
+			"curl header arg",
+			`curl -H "Authorization: Bearer abcdef123456" https://x.test`,
+			`curl -H "Authorization: Bearer ` + Mask + `" https://x.test`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := String(c.in); got != c.want {
+				t.Fatalf("String(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestStringPreservesNonCredentialBearerText is the anti-over-redaction guard for
+// the bearer pass. It pins all three precision boundaries: the header anchor is
+// required, a short synthetic placeholder is below the length gate, and a shell or
+// documentation placeholder is outside the b64token charset. The curl form is the
+// same fixture shape the rule catalog uses, so masking it would degrade unrelated
+// evidence.
+//
+// NOTE the deliberate boundary: once the header anchor matches, the length gate is
+// the only filter on what follows, so a word of prose after a literal
+// "Authorization: Bearer" IS masked ("...the Authorization: Bearer credential
+// must be rotated"). That is the accepted cost of a deterministic, explainable
+// rule — the alternative is entropy or dictionary guessing — and the anchor keeps
+// it confined to text already claiming to be an Authorization header. The cases
+// below stay preserved because each fails the charset or the length gate, not
+// because the pass second-guesses whether the value looks like a credential.
+func TestStringPreservesNonCredentialBearerText(t *testing.T) {
+	cases := []string{
+		"Authorization: Bearer test",                                             // 4-byte placeholder, under the length gate
+		"Authorization: Bearer tok123",                                           // 6-byte placeholder
+		"Authorization: Bearer abcd123",                                          // 7 bytes: one short of the gate
+		"Authorization: Bearer <token>",                                          // doc placeholder: '<' is not b64token
+		`curl --header "Authorization: Bearer $TOKEN" https://collector.example`, // shell variable, not b64token
+		"Bearer abcdef123456",                                                    // no header anchor: not a credential context
+		"the bearer of this message must be verified",                            // prose
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			if got := String(in); got != in {
+				t.Fatalf("non-credential bearer text over-redacted: %q -> %q", in, got)
+			}
+		})
 	}
 }
 
@@ -1294,6 +1507,11 @@ func FuzzString(f *testing.F) {
 		{"https://x.test#frag", ""},
 		{"%zz?x=", "&sig=%"},
 		{"", ">tail"},
+		// Position-driven passes: an authority scan and a header anchor must also
+		// survive truncated, nested, and unterminated input.
+		{"postgres://u:p@h", "&bar=2"},
+		{"redis://:@", "@:"},
+		{"Authorization: Bearer ", "&bar=2"},
 	}
 	for _, s := range seeds {
 		f.Add(s.prefix, s.suffix)
@@ -1303,6 +1521,18 @@ func FuzzString(f *testing.F) {
 		got := String(in) // must not panic
 		if strings.Contains(got, secret) {
 			t.Fatalf("secret survived redaction: %q -> %q", in, got)
+		}
+		// The position-driven passes carry the same no-leak property. The secret
+		// holds no byte that ends an authority scan or leaves the b64token
+		// charset, so arbitrary surrounding text must not rescue it: every
+		// counterexample here is a real leak, not a documented boundary.
+		dsn := prefix + "postgres://u:" + secret + "@h.test/db" + suffix
+		if got := String(dsn); strings.Contains(got, secret) {
+			t.Fatalf("userinfo password survived redaction: %q -> %q", dsn, got)
+		}
+		hdr := prefix + "\nAuthorization: Bearer " + secret + suffix
+		if got := String(hdr); strings.Contains(got, secret) {
+			t.Fatalf("bearer credential survived redaction: %q -> %q", hdr, got)
 		}
 		_ = String(prefix + suffix) // exercise arbitrary non-secret text for panics
 	})


### PR DESCRIPTION
## What this changes

`redact.String` did not catch two of the three credential shapes recorded in `TestStringKnownFalseNegatives`:

```
postgres://user:p4ssw0rd@host:5432/db
Authorization: Bearer abcdef123456
```

Neither carries a credential-looking key, so `maskCredentialValues` (exact query keys) and `maskAssignAll` (the `secretKey` regex) have nothing to anchor on, and neither has a self-describing prefix for `tokenPatterns`. Both do sit in a fixed grammatical position, so this masks them by position rather than by name, which keeps the anchoring style the rest of the file already uses:

- **`maskURLUserinfoPasswords`** — masks the password of an RFC 3986 authority for any scheme (`postgres://`, `redis://`, `mongodb+srv://`, and defanged `hxxp://`), keeping the username, host, port, and path readable. The userinfo ends at the **last** `@` in the authority and the password starts at the **first** `:` of the userinfo, so a password containing `@` or `:` is masked whole rather than leaving a head or tail. A colon-less userinfo (`scheme://token@host`) and an empty password are deliberately untouched.
- **`maskAuthorizationBearer`** — masks an RFC 6750 credential anchored on the `Authorization` header name (case-insensitive, unanchored on the left so `Proxy-Authorization` is covered) plus the literal `Bearer` scheme, over the b64token charset, with an 8-byte minimum and SP/HTAB separation.

`urlPattern` is untouched. Widening it would have extended the region where the assignment pass is suppressed and changed unrelated behavior, so the new scan uses its own sibling pattern.

### Why the mask inside a URL is percent-encoded

`userinfoMask` is `%5Bredacted%5D`, not the raw `Mask`. `net/url` rejects `[` and `]` in userinfo, so emitting `https://user:[redacted]@host/x` makes `canonicalizeURL` fail its parse and return `"", ""` — which drops the **entire** URL indicator, host and path included, rather than just the credential. `TestStringMasksURLUserinfoKeepsURLParseable` locks that reasoning. Nothing outside `internal/redact` keys on the literal `[redacted]` marker; `finding.redactValue` derives `redacted:true` from `out != raw`, so the flag is unaffected.

### Why the authority scan is short

The scan stops at the RFC authority end (`/?#`), at any byte a URI cannot contain (whitespace, controls, quote/brace/pipe wrappers, and **every non-ASCII byte**), and at the sub-delims that in practice separate list items or wrap a link (`,` `;` `&` `(` `)`).

Reading past any of those turns a benign line into a fabricated userinfo. `upstream=https://api.test:8443;user=ops@corp.test` would otherwise mask the **port** as a password, destroying the real `api.test` domain and `ops@corp.test` email indicators and inventing a `url`/`domain` for `corp.test` that never appeared in the source. A CJK sentence or a no-break space pasted from a page is enough to bridge it, and the IPv6 form additionally produced a string that no longer parsed as a URL. `TestStringPreservesURLWithoutUserinfoPassword` pins each of those shapes — CSV rows, `;`/`&` pair lists, markdown links, env lists, CJK prose, NBSP, em dash.

## Contract effects

- **Security.** Two credential classes that previously reached case bundles, findings, timelines, and indicator output are now masked. One pre-existing leak is closed as a side effect: a DSN password used to be republished as an `email` indicator (`p4ssw0rd@host.test`); it is now the masked value.
- **High precision, no fabrication** (CONTRIBUTING.md:61-62). Every widening here is anchored on syntax, not on a word that looks secret, and each new masking test is paired with an anti-over-redaction test. Accepted false negatives are recorded as executable assertions rather than comments.
- **Schema / wire contract.** None. No record shape, field, or `schema_version` change, so no JSON Schema or migration work. Output for affected fields changes value only.
- **Rule versions.** None; no rule or rule metadata is touched.
- **Compatibility.** `redact.String`'s signature and determinism are unchanged, and it stays idempotent. A consumer that string-matches an emitted URL's userinfo will now see `%5Bredacted%5D`; `docs/cli.md` documents that form.
- **Architecture boundaries.** Change is confined to `internal/redact` plus a docs note. `credentialQueryKeys`, `secretKey`, `assignPatterns`, `tokenPatterns`, and `urlPattern` keep their semantics, and no new dependency is added (the test file uses `net/url` from the standard library).

## False negatives, deliberately kept

`TestStringKnownFalseNegatives` now locks four classes instead of three, with the reasoning in the test's doc comment:

1. **Bare AWS secret access key** — unchanged, and intended as permanent. 40 arbitrary base64 bytes offer no prefix, key, or grammatical position; the only pattern that would catch it is a generic 40-char shape that would also mask hashes, git object ids, and random identifiers in benign output.
2. **Userinfo holding a byte that ends the authority scan** — an unencoded `/`, whitespace, a non-ASCII byte, or a list separator, in the **username** as well as the password. The scan finds no `@` and masks nothing, so these are clean non-matches, never partial masks. RFC 3986 requires percent-encoding for all but the sub-delims, and the percent-encoded spellings do mask. Widening the scan to recover them was measured to be worse: it reads a benign path such as `/download/file@2x.png` as userinfo.
3. **Bearer credential in a subscript or call form** — `headers["Authorization"] = "Bearer ..."`. The header name must be followed directly by the operator; admitting one such spelling invites every other quoting and accessor syntax with no principled place to stop.
4. **Bearer credential under 8 bytes, or obs-folded across a newline** — documented on `authorizationBearerPattern`. The 8-byte floor keeps short placeholders (`Bearer test`, `Bearer tok123`) readable; SP/HTAB-only separation keeps a multi-line content preview from having its next line masked.

Note that once the header anchor matches, the length gate is the only filter, so a word of prose directly after a literal `Authorization: Bearer` is masked too. That is deliberate — the alternative is entropy or dictionary guessing, which is neither deterministic nor explainable — and it is recorded in the pattern comment and on `TestStringPreservesNonCredentialBearerText`.

## Tests

- `TestStringMasksURLUserinfoPassword` and `TestStringMasksAuthorizationBearer` assert **exact output**, not the absence of the secret: the two span rules are indistinguishable from their leaking variants under a substring check, since masking `p@ss` as `%5Bredacted%5D@ss` removes the substring `p@ss` while still leaking `ss`.
- `TestStringPreservesURLWithoutUserinfoPassword` and `TestStringPreservesNonCredentialBearerText` are the paired anti-over-redaction guards.
- `TestStringMasksURLUserinfoKeepsURLParseable` pins the reason the in-URL mask is percent-encoded.
- `FuzzString` now asserts a real no-leak property for each new pass (a `postgres://u:<secret>@h.test/db` form and an `Authorization: Bearer <secret>` form) instead of only exercising them for panics.

I also mutation-checked the new code rather than trusting the assertions: reverting the non-ASCII terminator, dropping any one of `,` `;` `&` `(` `)`, swapping first/last `@` or `:`, shifting either end of the mask span by one, dropping the empty-password guard, moving the bearer floor to 7 or 9, removing the header anchor, restricting the scheme pattern to `https?`, and no-oping either pass are each caught by the suite.

## Verification

Run from the repository root on Go 1.26.5, with the CI-pinned tool versions (`golangci-lint v2.12.2`, `govulncheck v1.6.0`):

```sh
go mod tidy
git diff --exit-code -- go.mod go.sum
gofmt -l .
go vet ./...
go test -race ./...
go build -buildvcs=false ./cmd/numbat
golangci-lint run
golangci-lint fmt --diff
govulncheck ./...
go test -run='^$' -fuzz='^FuzzString$' -fuzztime=30s ./internal/redact/
```

All pass: `gofmt -l .` prints nothing, `golangci-lint run` reports 0 issues, `golangci-lint fmt --diff` is empty, `go test -race ./...` is ok across all 17 packages with tests, `govulncheck` finds no vulnerabilities, and the fuzz target passed at 30s and again at 60s with no crasher written.

## Open question for reviewers

`maskURLUserinfoPasswords` keeps an `if authStart < last { continue }` guard that is provably unreachable today, since `authorityEnd` stops at the `/` that any later `://` must contain. It stays because the splice indexes `s[last:pwStart]`, so if that invariant were ever broken the alternative to skipping is a panic on a redaction path. Happy to drop it if you would rather not carry an unreachable branch.
