### PR TITLE
Retain Codex code-mode command outcomes

### DIFF
--- a/internal/extract/codex.go
+++ b/internal/extract/codex.go
@@ -70,10 +70,9 @@ type codexState struct {
 	// the paired function_call_output is promoted from tool.result to
 	// command.result. A non-shell call's id never enters the set.
 	shellCallIDs map[string]struct{}
-	// codeModeShellCallIDs records custom exec cells that were safely reduced to
-	// one command.exec, so only their custom_tool_call_output becomes a
-	// command.result. Keeping the sets separate prevents cross-variant collisions.
-	codeModeShellCallIDs map[string]struct{}
+	// codeModeShellCalls records how a safely reduced exec cell forwarded its
+	// result, so the paired custom output is decoded without scraping stdout.
+	codeModeShellCalls map[string]codexCodeModeResultKind
 	// failedMCPCallIDs is the set of call_ids whose mcp_tool_call_end recorded a
 	// structured failure. A custom_tool_call_output emitted AFTER its end-event
 	// consults this so it still carries the tool-error signal regardless of the
@@ -117,24 +116,24 @@ func (st *codexState) isShellCall(id string) bool {
 	return ok
 }
 
-func (st *codexState) noteCodeModeShellCall(id string) {
+func (st *codexState) noteCodeModeShellCall(id string, resultKind codexCodeModeResultKind) {
 	if id == "" {
 		return
 	}
-	if st.codeModeShellCallIDs == nil {
-		st.codeModeShellCallIDs = map[string]struct{}{}
+	if st.codeModeShellCalls == nil {
+		st.codeModeShellCalls = map[string]codexCodeModeResultKind{}
 	}
-	st.codeModeShellCallIDs[id] = struct{}{}
+	st.codeModeShellCalls[id] = resultKind
 }
 
 func (st *codexState) forgetCodeModeShellCall(id string) {
-	delete(st.codeModeShellCallIDs, id)
+	delete(st.codeModeShellCalls, id)
 }
 
-func (st *codexState) takeCodeModeShellCall(id string) bool {
-	_, ok := st.codeModeShellCallIDs[id]
-	delete(st.codeModeShellCallIDs, id)
-	return ok
+func (st *codexState) takeCodeModeShellCall(id string) (codexCodeModeResultKind, bool) {
+	resultKind, ok := st.codeModeShellCalls[id]
+	delete(st.codeModeShellCalls, id)
+	return resultKind, ok
 }
 
 // Extract parses a Codex rollout file. It reads the whole artifact to stamp a
@@ -342,16 +341,16 @@ func (e CodexExtractor) mapResponseItem(res *Result, src Source, sha string, st 
 			return
 		}
 		if ri.Name == codexToolCodeModeExec {
-			if command, ok := codexCodeModeExecCommand(string(ri.Input)); ok {
+			if call, ok := parseCodexCodeModeExec(string(ri.Input)); ok {
 				ev := e.base(src, sha, st, line, ts, 0)
 				ev.Actor = model.ActorAssistant
 				ev.Confidence = model.ConfidenceHigh
 				ev.ToolName = codexToolExecCommand
 				ev.ToolCallID = ri.CallID
 				ev.EventType = model.EventCommandExec
-				ev.Command = command
+				ev.Command = call.command
 				ev.Evidence.JSONPointer = "/payload/input"
-				st.noteCodeModeShellCall(ri.CallID)
+				st.noteCodeModeShellCall(ri.CallID, call.resultKind)
 				res.Events = append(res.Events, ev)
 				return
 			}
@@ -389,38 +388,49 @@ func (e CodexExtractor) mapResponseItem(res *Result, src Source, sha string, st 
 		ev.Actor = model.ActorTool
 		ev.Confidence = model.ConfidenceHigh
 		ev.ToolCallID = ri.CallID
-		ev.ContentPreview = preview(decodeCodexOutput(ri.Output))
+		resultBody := decodeCodexOutput(ri.Output)
 		ev.Evidence.JSONPointer = "/payload/output"
 		// An output paired by call_id with the matching shell-call variant is a
 		// command.result. Other function/custom outputs stay tool.result.
 		//
-		// A shell command.result's ExitCode stays nil: Codex serializes a
-		// function_call_output as only its body (FunctionCallOutputPayload in
-		// protocol/src/models.rs drops the internal success flag and writes no
-		// structured exit code — the code appears only as a free-text
-		// "Exit code: N" line in the body, too brittle to lift), and the structured
-		// ExecCommandEnd carrying the real code is not persisted to the rollout. So
-		// there is no faithful structured shell exit status to attach, and numbat
-		// never scrapes the prose body for one. The shell tool-error signal is
-		// likewise unrecoverable at rest: local_shell_call's status enum is
-		// Completed|InProgress|Incomplete with no failure variant (Incomplete is an
-		// abort/limit, not a tool error). See
-		// TestExtractCodexShellResultHasNoStructuredExitOrError.
+		// Legacy shell outputs persist only prose, so their exit status remains
+		// unset. Current code-mode outputs can carry the exec helper's structured
+		// result; decode it only when the statically parsed cell forwarded that
+		// object, never by interpreting JSON-looking stdout.
 		//
 		// An MCP tool failure, by contrast, IS recoverable: the persisted
 		// mcp_tool_call_end carries a structured Result keyed by this call_id, and
 		// mapEventMsg stamps TagToolError on this tool.result when it records a
 		// failure. When the end-event already arrived (it preceded this output), the
 		// failure was recorded in state, so tag here too.
+		var codeModeResultKind codexCodeModeResultKind
+		var codeModeResult bool
+		if ri.Type == codexRICustomToolCallOut {
+			codeModeResultKind, codeModeResult = st.takeCodeModeShellCall(ri.CallID)
+		}
 		if (ri.Type == codexRIFunctionCallOutput && st.isShellCall(ri.CallID)) ||
-			(ri.Type == codexRICustomToolCallOut && st.takeCodeModeShellCall(ri.CallID)) {
+			(ri.Type == codexRICustomToolCallOut && codeModeResult) {
 			ev.EventType = model.EventCommandResult
+			if codeModeResult {
+				ev.ToolName = codexToolExecCommand
+				outcome := decodeCodexCodeModeOutcome(ri.Output, codeModeResultKind)
+				resultBody = outcome.output
+				ev.ExitCode = outcome.exitCode
+				ev.DurationMs = outcome.durationMs
+				if outcome.toolError {
+					ev.Tags = append(ev.Tags, model.TagToolError)
+				}
+				if !outcome.recognized {
+					res.diag(src.Path, line, "unrecognized code-mode result envelope")
+				}
+			}
 		} else {
 			ev.EventType = model.EventToolResult
 			if st.isFailedMCPCall(ri.CallID) {
 				ev.Tags = append(ev.Tags, model.TagToolError)
 			}
 		}
+		ev.ContentPreview = preview(resultBody)
 		res.Events = append(res.Events, ev)
 	case codexRIToolSearchOutput:
 		// The result of a tool_search_call (the model discovering which tools

--- a/internal/extract/codex_code_mode.go
+++ b/internal/extract/codex_code_mode.go
@@ -2,6 +2,7 @@ package extract
 
 import (
 	"encoding/json"
+	"math"
 	"regexp"
 	"strings"
 )
@@ -13,29 +14,55 @@ var codexCodeModeExecPrefix = regexp.MustCompile(`^const[[:space:]]+([A-Za-z_$][
 
 const codexCodeModeStringToken = "<string>"
 
+type codexCodeModeResultKind uint8
+
+const (
+	codexCodeModeResultNone codexCodeModeResultKind = iota
+	codexCodeModeResultOutput
+	codexCodeModeResultObject
+)
+
+type codexCodeModeExec struct {
+	command    string
+	resultKind codexCodeModeResultKind
+}
+
+type codexCodeModeOutcome struct {
+	output     string
+	exitCode   *int
+	durationMs *int64
+	toolError  bool
+	recognized bool
+}
+
 func codexCodeModeExecCommand(input string) (string, bool) {
+	call, ok := parseCodexCodeModeExec(input)
+	return call.command, ok
+}
+
+func parseCodexCodeModeExec(input string) (codexCodeModeExec, bool) {
 	s := strings.TrimSpace(input)
 	if strings.HasPrefix(s, "// @exec:") {
 		newline := strings.IndexByte(s, '\n')
 		if newline < 0 {
-			return "", false
+			return codexCodeModeExec{}, false
 		}
 		s = strings.TrimSpace(s[newline+1:])
 	}
 
 	match := codexCodeModeExecPrefix.FindStringSubmatchIndex(s)
 	if match == nil || !isCodexCodeModeBindingName(s[match[2]:match[3]]) {
-		return "", false
+		return codexCodeModeExec{}, false
 	}
 	resultName := s[match[2]:match[3]]
 
 	command, end, ok := parseCodexCodeModeExecArgs(s, match[1])
 	if !ok {
-		return "", false
+		return codexCodeModeExec{}, false
 	}
 	end = skipASCIIWhitespace(s, end)
 	if end >= len(s) || s[end] != ')' {
-		return "", false
+		return codexCodeModeExec{}, false
 	}
 	end++
 	var lineBreak bool
@@ -46,39 +73,125 @@ func codexCodeModeExecCommand(input string) (string, bool) {
 		separated = true
 	}
 	if skipASCIIWhitespace(s, end) < len(s) && !separated {
-		return "", false
+		return codexCodeModeExec{}, false
 	}
 
 	// Accept only an empty tail or the common result-forwarding forms. Any other
 	// JavaScript may contain another operation or alter the meaning of the output.
-	if !isCodexCodeModeResultTail(s[end:], resultName) {
-		return "", false
+	resultKind, ok := codexCodeModeResultTail(s[end:], resultName)
+	if !ok {
+		return codexCodeModeExec{}, false
 	}
-	return command, true
+	return codexCodeModeExec{command: command, resultKind: resultKind}, true
 }
 
-func isCodexCodeModeResultTail(s, resultName string) bool {
+func codexCodeModeResultTail(s, resultName string) (codexCodeModeResultKind, bool) {
 	tokens, ok := codexCodeModeTailTokens(s)
 	if !ok {
-		return false
+		return codexCodeModeResultNone, false
 	}
 	if len(tokens) == 0 {
-		return true
+		return codexCodeModeResultNone, true
 	}
 	if tokens[len(tokens)-1] == ";" {
 		tokens = tokens[:len(tokens)-1]
 	}
 	// These declarations shadow helpers used by the corresponding tail shape.
 	if resultName == "text" {
-		return false
+		return codexCodeModeResultNone, false
 	}
-	if codexCodeModeTokensEqual(tokens, "text", "(", resultName, ")") ||
-		codexCodeModeTokensEqual(tokens, "text", "(", resultName, ".", "output", ")") ||
+	if codexCodeModeTokensEqual(tokens, "text", "(", resultName, ")") {
+		return codexCodeModeResultObject, true
+	}
+	if codexCodeModeTokensEqual(tokens, "text", "(", resultName, ".", "output", ")") ||
 		codexCodeModeTokensEqual(tokens, "text", "(", resultName, ".", "output", "||", codexCodeModeStringToken, ")") {
-		return true
+		return codexCodeModeResultOutput, true
 	}
-	return resultName != "JSON" && codexCodeModeTokensEqual(tokens,
-		"text", "(", "JSON", ".", "stringify", "(", resultName, ")", ")")
+	if resultName != "JSON" && codexCodeModeTokensEqual(tokens,
+		"text", "(", "JSON", ".", "stringify", "(", resultName, ")", ")") {
+		return codexCodeModeResultObject, true
+	}
+	return codexCodeModeResultNone, false
+}
+
+var (
+	codexCodeModeOutputEnvelope  = regexp.MustCompile(`^Script completed\nWall time [0-9]+(?:\.[0-9]+)? seconds\nOutput:\n$`)
+	codexCodeModeFailedEnvelope  = regexp.MustCompile(`^Script failed\nWall time [0-9]+(?:\.[0-9]+)? seconds\nOutput:\n$`)
+	codexCodeModeRunningEnvelope = regexp.MustCompile(`^Script running with cell ID [^\n]+\nWall time [0-9]+(?:\.[0-9]+)? seconds\nOutput:\n`)
+)
+
+func decodeCodexCodeModeOutput(raw json.RawMessage) (string, bool) {
+	return decodeCodexCodeModeEnvelope(raw, codexCodeModeOutputEnvelope)
+}
+
+func decodeCodexCodeModeEnvelope(raw json.RawMessage, envelope *regexp.Regexp) (string, bool) {
+	var items []codexContentItem
+	if json.Unmarshal(raw, &items) != nil || len(items) != 2 ||
+		items[0].Type != "input_text" || items[1].Type != "input_text" ||
+		!envelope.MatchString(items[0].Text) {
+		return "", false
+	}
+	return items[1].Text, true
+}
+
+func decodeCodexCodeModeOutcome(raw json.RawMessage, kind codexCodeModeResultKind) codexCodeModeOutcome {
+	outcome := codexCodeModeOutcome{
+		output:     decodeCodexOutput(raw),
+		recognized: kind != codexCodeModeResultObject,
+	}
+	if body, ok := decodeCodexCodeModeEnvelope(raw, codexCodeModeFailedEnvelope); ok {
+		outcome.output = body
+		outcome.toolError = true
+		outcome.recognized = true
+		return outcome
+	}
+	if body, ok := decodeCodexCodeModeOutput(raw); ok {
+		outcome.output = body
+	}
+	if kind != codexCodeModeResultObject {
+		return outcome
+	}
+	if isCodexCodeModeRunningOutput(raw) {
+		outcome.recognized = true
+		return outcome
+	}
+
+	body, exitCode, durationMs, ok := decodeCodexCodeModeResultObject(raw)
+	if !ok {
+		return outcome
+	}
+	outcome.output = body
+	outcome.exitCode = exitCode
+	outcome.durationMs = durationMs
+	outcome.toolError = exitCode != nil && *exitCode != 0
+	outcome.recognized = true
+	return outcome
+}
+
+func decodeCodexCodeModeResultObject(raw json.RawMessage) (output string, exitCode *int, durationMs *int64, ok bool) {
+	body, ok := decodeCodexCodeModeOutput(raw)
+	if !ok {
+		return "", nil, nil, false
+	}
+	var result struct {
+		ExitCode        *int     `json:"exit_code"`
+		Output          *string  `json:"output"`
+		WallTimeSeconds *float64 `json:"wall_time_seconds"`
+	}
+	if json.Unmarshal([]byte(body), &result) != nil || result.Output == nil {
+		return "", nil, nil, false
+	}
+	if result.ExitCode != nil && result.WallTimeSeconds != nil &&
+		*result.WallTimeSeconds >= 0 && *result.WallTimeSeconds < float64(math.MaxInt64/1000) {
+		milliseconds := int64(math.Round(*result.WallTimeSeconds * 1000))
+		durationMs = &milliseconds
+	}
+	return *result.Output, result.ExitCode, durationMs, true
+}
+
+func isCodexCodeModeRunningOutput(raw json.RawMessage) bool {
+	var output string
+	return json.Unmarshal(raw, &output) == nil && codexCodeModeRunningEnvelope.MatchString(output)
 }
 
 func codexCodeModeTailTokens(s string) ([]string, bool) {

--- a/internal/extract/codex_code_mode_test.go
+++ b/internal/extract/codex_code_mode_test.go
@@ -29,6 +29,95 @@ func TestExtractCodexCodeModeCommandAndResult(t *testing.T) {
 	}
 }
 
+func TestExtractCodexCodeModeStructuredResult(t *testing.T) {
+	input := `const r = await tools.exec_command({cmd:"false"}); text(JSON.stringify(r));`
+	body := strings.Join([]string{
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"e1","input":` + jsonString(input) + `}}`,
+		`{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"e1","output":[{"type":"input_text","text":"Script completed\nWall time 0.2 seconds\nOutput:\n"},{"type":"input_text","text":"{\"chunk_id\":\"c1\",\"exit_code\":7,\"wall_time_seconds\":0.1256,\"output\":\"permission denied\\n\"}"}]}}`,
+	}, "\n")
+	acts := activityEvents(extractCodex(t, body).Events)
+	if len(acts) != 2 {
+		t.Fatalf("got %d activity events, want 2: %s", len(acts), dumpEvents(acts))
+	}
+	result := acts[1]
+	if result.EventType != model.EventCommandResult || result.ToolName != codexToolExecCommand ||
+		result.ContentPreview != "permission denied" || result.ExitCode == nil || *result.ExitCode != 7 ||
+		result.DurationMs == nil || *result.DurationMs != 126 || !hasTag(result.Tags, model.TagToolError) {
+		t.Fatalf("result = %+v, want structured failed command result", result)
+	}
+}
+
+func TestExtractCodexCodeModeRunningResultHasNoFinalOutcome(t *testing.T) {
+	input := `const r = await tools.exec_command({cmd:"sleep 10"}); text(r);`
+	body := strings.Join([]string{
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"e1","input":` + jsonString(input) + `}}`,
+		`{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"e1","output":[{"type":"input_text","text":"Script completed\nWall time 1.2 seconds\nOutput:\n"},{"type":"input_text","text":"{\"chunk_id\":\"c1\",\"session_id\":42,\"wall_time_seconds\":1.001,\"output\":\"Process running\"}"}]}}`,
+	}, "\n")
+	acts := activityEvents(extractCodex(t, body).Events)
+	if len(acts) != 2 {
+		t.Fatalf("got %d activity events, want 2: %s", len(acts), dumpEvents(acts))
+	}
+	result := acts[1]
+	if result.EventType != model.EventCommandResult || result.ContentPreview != "Process running" ||
+		result.ExitCode != nil || result.DurationMs != nil || hasTag(result.Tags, model.TagToolError) {
+		t.Fatalf("result = %+v, want non-final running result", result)
+	}
+}
+
+func TestExtractCodexCodeModeRunningEnvelopeHasNoFinalOutcome(t *testing.T) {
+	input := `const r = await tools.exec_command({cmd:"sleep 10"}); text(r);`
+	body := strings.Join([]string{
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"e1","input":` + jsonString(input) + `}}`,
+		`{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"e1","output":"Script running with cell ID 18\nWall time 11.0 seconds\nOutput:\n"}}`,
+	}, "\n")
+	res := extractCodex(t, body)
+	acts := activityEvents(res.Events)
+	if len(acts) != 2 {
+		t.Fatalf("got %d activity events, want 2: %s", len(acts), dumpEvents(acts))
+	}
+	result := acts[1]
+	if result.EventType != model.EventCommandResult || result.ExitCode != nil ||
+		result.DurationMs != nil || hasTag(result.Tags, model.TagToolError) || len(res.Diagnostics) != 0 {
+		t.Fatalf("result = %+v, diagnostics = %+v; want a non-final running result", result, res.Diagnostics)
+	}
+}
+
+func TestExtractCodexCodeModeFailedEnvelopeIsToolError(t *testing.T) {
+	input := `const r = await tools.exec_command({cmd:"missing"}); text(JSON.stringify(r));`
+	body := strings.Join([]string{
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"e1","input":` + jsonString(input) + `}}`,
+		`{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"e1","output":[{"type":"input_text","text":"Script failed\nWall time 0.1 seconds\nOutput:\n"},{"type":"input_text","text":"Script error:\nprocess could not start"}]}}`,
+	}, "\n")
+	res := extractCodex(t, body)
+	acts := activityEvents(res.Events)
+	if len(acts) != 2 {
+		t.Fatalf("got %d activity events, want 2: %s", len(acts), dumpEvents(acts))
+	}
+	result := acts[1]
+	if result.EventType != model.EventCommandResult || result.ContentPreview != "Script error: process could not start" ||
+		result.ExitCode != nil || result.DurationMs != nil || !hasTag(result.Tags, model.TagToolError) || len(res.Diagnostics) != 0 {
+		t.Fatalf("result = %+v, diagnostics = %+v; want a structured tool error without an exit code", result, res.Diagnostics)
+	}
+}
+
+func TestExtractCodexCodeModeStdoutJSONIsNotAnOutcome(t *testing.T) {
+	input := `const r = await tools.exec_command({cmd:"cat result.json"}); text(r.output);`
+	stdout := `{"exit_code":9,"wall_time_seconds":2,"output":"not metadata"}`
+	body := strings.Join([]string{
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"e1","input":` + jsonString(input) + `}}`,
+		`{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"e1","output":[{"type":"input_text","text":"Script completed\nWall time 0.1 seconds\nOutput:\n"},{"type":"input_text","text":` + jsonString(stdout) + `}]}}`,
+	}, "\n")
+	acts := activityEvents(extractCodex(t, body).Events)
+	if len(acts) != 2 {
+		t.Fatalf("got %d activity events, want 2: %s", len(acts), dumpEvents(acts))
+	}
+	result := acts[1]
+	if result.EventType != model.EventCommandResult || result.ContentPreview != stdout ||
+		result.ExitCode != nil || result.DurationMs != nil || hasTag(result.Tags, model.TagToolError) {
+		t.Fatalf("result = %+v, stdout JSON must remain content only", result)
+	}
+}
+
 func TestCodexCodeModeCommandAcceptsDocumentedPragmaAndQuotedKeys(t *testing.T) {
 	input := "// @exec: {\"yield_time_ms\": 10000}\n" +
 		`const result = await tools.exec_command({"cmd":"git status","workdir":"/repo",}); text(JSON.stringify(result));`

--- a/internal/extract/openclaw.go
+++ b/internal/extract/openclaw.go
@@ -52,10 +52,9 @@ type openClawState struct {
 	projectPath      string
 	currentTimestamp string
 	commandCalls     map[string]struct{}
-	// codexCodeModeCommandCalls is separate from commandCalls so an unrelated
-	// custom output cannot inherit a direct function call's classification when
-	// a malformed transcript reuses a call id.
-	codexCodeModeCommandCalls map[string]struct{}
+	// codexCodeModeCommandCalls records how an embedded Codex exec cell forwards
+	// its result. It remains separate from direct function-call correlation.
+	codexCodeModeCommandCalls map[string]codexCodeModeResultKind
 	// failedMCPCallIDs is the set of call_ids whose Codex-flavor mcp_tool_call_end
 	// recorded a structured failure BEFORE the matching custom_tool_call_output was
 	// emitted. The later output consults this so it still carries the tool-error
@@ -84,24 +83,24 @@ func (st *openClawState) isCommandCall(id string) bool {
 	return ok
 }
 
-func (st *openClawState) noteCodexCodeModeCommandCall(id string) {
+func (st *openClawState) noteCodexCodeModeCommandCall(id string, resultKind codexCodeModeResultKind) {
 	if id == "" {
 		return
 	}
 	if st.codexCodeModeCommandCalls == nil {
-		st.codexCodeModeCommandCalls = map[string]struct{}{}
+		st.codexCodeModeCommandCalls = map[string]codexCodeModeResultKind{}
 	}
-	st.codexCodeModeCommandCalls[id] = struct{}{}
+	st.codexCodeModeCommandCalls[id] = resultKind
 }
 
 func (st *openClawState) forgetCodexCodeModeCommandCall(id string) {
 	delete(st.codexCodeModeCommandCalls, id)
 }
 
-func (st *openClawState) takeCodexCodeModeCommandCall(id string) bool {
-	_, ok := st.codexCodeModeCommandCalls[id]
+func (st *openClawState) takeCodexCodeModeCommandCall(id string) (codexCodeModeResultKind, bool) {
+	resultKind, ok := st.codexCodeModeCommandCalls[id]
 	delete(st.codexCodeModeCommandCalls, id)
-	return ok
+	return resultKind, ok
 }
 
 // noteFailedMCPCall records a call_id whose mcp_tool_call_end reported a

--- a/internal/extract/openclaw_codex.go
+++ b/internal/extract/openclaw_codex.go
@@ -23,9 +23,8 @@ import (
 // the matching tool.result TagToolError, and the no-twin state transitions
 // (turn_aborted / thread_rolled_back / review-mode / thread-goal) become
 // low-confidence system notes (see mapCodexEventMsg). Per the high-precision
-// boundary, NO shell exit code is emitted (Codex's function_call_output carries
-// no structured exit field — see codex.go) and a tool-error tag is set only from
-// a structured field.
+// boundary, legacy shell output never has its prose scraped for an exit code,
+// and a tool-error tag is set only from a structured field.
 
 // mapCodexLine decodes one Codex-flavor OpenClaw line and dispatches on the
 // outer record type. A malformed line is a diagnostic and is skipped; the rest of
@@ -119,13 +118,30 @@ func (e OpenClawExtractor) mapCodexResponseItem(res *Result, src Source, sha str
 		ev.Confidence = model.ConfidenceHigh
 		ev.ToolCallID = ri.CallID
 		ev.Evidence.JSONPointer = "/payload/output"
-		ev.ContentPreview = preview(decodeCodexOutput(ri.Output))
+		resultBody := decodeCodexOutput(ri.Output)
 		// An output paired with the matching shell-call variant is a
-		// command.result; every other output stays tool.result. No exit code is
-		// emitted because Codex does not persist one in these response items.
+		// command.result; every other output stays tool.result.
+		var codeModeResultKind codexCodeModeResultKind
+		var codeModeResult bool
+		if ri.Type == codexRICustomToolCallOut {
+			codeModeResultKind, codeModeResult = st.takeCodexCodeModeCommandCall(ri.CallID)
+		}
 		if (ri.Type == codexRIFunctionCallOutput && st.isCommandCall(ri.CallID)) ||
-			(ri.Type == codexRICustomToolCallOut && st.takeCodexCodeModeCommandCall(ri.CallID)) {
+			(ri.Type == codexRICustomToolCallOut && codeModeResult) {
 			ev.EventType = model.EventCommandResult
+			if codeModeResult {
+				ev.ToolName = codexToolExecCommand
+				outcome := decodeCodexCodeModeOutcome(ri.Output, codeModeResultKind)
+				resultBody = outcome.output
+				ev.ExitCode = outcome.exitCode
+				ev.DurationMs = outcome.durationMs
+				if outcome.toolError {
+					ev.Tags = append(ev.Tags, model.TagToolError)
+				}
+				if !outcome.recognized {
+					res.diag(src.Path, line, "unrecognized code-mode result envelope")
+				}
+			}
 		} else {
 			ev.EventType = model.EventToolResult
 			// An mcp_tool_call_end may have recorded this call's failure before its
@@ -135,6 +151,7 @@ func (e OpenClawExtractor) mapCodexResponseItem(res *Result, src Source, sha str
 				ev.Tags = append(ev.Tags, model.TagToolError)
 			}
 		}
+		ev.ContentPreview = preview(resultBody)
 		res.appendEvent(st, ev, true)
 	case codexRIWebSearchCall:
 		ev := e.base(src, sha, st, line, 0)
@@ -159,16 +176,16 @@ func (e OpenClawExtractor) mapCodexResponseItem(res *Result, src Source, sha str
 		// A later custom call reusing a malformed call id owns its next output.
 		st.forgetCodexCodeModeCommandCall(ri.CallID)
 		if ri.Name == codexToolCodeModeExec {
-			if command, ok := codexCodeModeExecCommand(string(ri.Input)); ok {
+			if call, ok := parseCodexCodeModeExec(string(ri.Input)); ok {
 				ev := e.base(src, sha, st, line, 0)
 				ev.Actor = model.ActorAssistant
 				ev.Confidence = model.ConfidenceHigh
 				ev.ToolName = codexToolExecCommand
 				ev.ToolCallID = ri.CallID
 				ev.EventType = model.EventCommandExec
-				ev.Command = command
+				ev.Command = call.command
 				ev.Evidence.JSONPointer = "/payload/input"
-				st.noteCodexCodeModeCommandCall(ri.CallID)
+				st.noteCodexCodeModeCommandCall(ri.CallID, call.resultKind)
 				res.appendEvent(st, ev, true)
 				return
 			}

--- a/internal/extract/openclaw_test.go
+++ b/internal/extract/openclaw_test.go
@@ -834,11 +834,11 @@ func TestOpenClawCodexResponseItemParity(t *testing.T) {
 }
 
 func TestOpenClawEmbeddedCodexCodeModeParity(t *testing.T) {
-	input := `const r = await tools.exec_command({cmd:"git status", workdir:"/w"}); text(r.output);`
+	input := `const r = await tools.exec_command({cmd:"git status", workdir:"/w"}); text(r);`
 	lines := []string{
 		`{"timestamp":"t","type":"session_meta","payload":{"id":"cx-code","cwd":"/w"}}`,
 		`{"timestamp":"t","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"code1","input":` + jsonString(input) + `}}`,
-		`{"timestamp":"t","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"code1","output":"clean"}}`,
+		`{"timestamp":"t","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"code1","output":[{"type":"input_text","text":"Script completed\nWall time 0.1 seconds\nOutput:\n"},{"type":"input_text","text":"{\"exit_code\":3,\"wall_time_seconds\":0.012,\"output\":\"failed\\n\"}"}]}}`,
 	}
 	res := extractOpenClaw(t, strings.Join(lines, "\n"))
 	if len(res.Events) != 2 {
@@ -848,7 +848,10 @@ func TestOpenClawEmbeddedCodexCodeModeParity(t *testing.T) {
 	if call.EventType != model.EventCommandExec || call.ToolName != codexToolExecCommand || call.Command != "git status" {
 		t.Errorf("call = %+v, want code-mode command.exec", call)
 	}
-	if result.EventType != model.EventCommandResult || result.ToolCallID != "code1" || result.ContentPreview != "clean" {
+	if result.EventType != model.EventCommandResult || result.ToolCallID != "code1" ||
+		result.ToolName != codexToolExecCommand || result.ContentPreview != "failed" ||
+		result.ExitCode == nil || *result.ExitCode != 3 || result.DurationMs == nil ||
+		*result.DurationMs != 12 || !hasTag(result.Tags, model.TagToolError) {
 		t.Errorf("result = %+v, want correlated command.result with preview", result)
 	}
 	assertOpenClawPointersResolve(t, res, lines)


### PR DESCRIPTION
## Summary
- correlate code-mode `exec_command` results with their normalized command events
- retain command output without duplicating generic wrapper events
- cover direct Codex and OpenClaw-wrapped records

Stacked on #7.

## Validation
- `go test ./internal/extract`