### PR TITLE
Correlate long-running Codex command outcomes

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -153,6 +153,10 @@ actions are specialized the same way. `tool.call` is the fallback when numbat
 cannot safely specialize the action. A later `command.result` is the correlated
 outcome, not a second invocation.
 
+Long-running commands may produce multiple `command.result` updates with the
+same `tool_call_id`. A missing `exit_code` means the source did not report one;
+it does not imply success.
+
 Do not add `tool.call` as a catch-all branch to a command rule. Generic tool
 calls have no `event.command`; write a separate tool rule only when the generic
 tool identity is itself the signal.

--- a/internal/extract/codex.go
+++ b/internal/extract/codex.go
@@ -70,9 +70,9 @@ type codexState struct {
 	// the paired function_call_output is promoted from tool.result to
 	// command.result. A non-shell call's id never enters the set.
 	shellCallIDs map[string]struct{}
-	// codeModeShellCalls records how a safely reduced exec cell forwarded its
-	// result, so the paired custom output is decoded without scraping stdout.
-	codeModeShellCalls map[string]codexCodeModeResultKind
+	// codeMode correlates static exec cells through Codex's internal wait/poll
+	// calls so long-running commands keep one semantic identity.
+	codeMode codexCodeModeTracker
 	// failedMCPCallIDs is the set of call_ids whose mcp_tool_call_end recorded a
 	// structured failure. A custom_tool_call_output emitted AFTER its end-event
 	// consults this so it still carries the tool-error signal regardless of the
@@ -92,9 +92,10 @@ func (st *codexState) noteFailedMCPCall(id string) {
 	st.failedMCPCallIDs[id] = struct{}{}
 }
 
-// isFailedMCPCall reports whether call_id's mcp_tool_call_end reported failure.
-func (st *codexState) isFailedMCPCall(id string) bool {
+// takeFailedMCPCall consumes a deferred MCP failure for a tool result.
+func (st *codexState) takeFailedMCPCall(id string) bool {
 	_, ok := st.failedMCPCallIDs[id]
+	delete(st.failedMCPCallIDs, id)
 	return ok
 }
 
@@ -110,30 +111,17 @@ func (st *codexState) noteShellCall(id string) {
 	st.shellCallIDs[id] = struct{}{}
 }
 
-// isShellCall reports whether call_id was a recorded shell command.exec.
-func (st *codexState) isShellCall(id string) bool {
+// takeShellCall consumes the command owner for a function-call output.
+func (st *codexState) takeShellCall(id string) bool {
 	_, ok := st.shellCallIDs[id]
+	delete(st.shellCallIDs, id)
 	return ok
 }
 
-func (st *codexState) noteCodeModeShellCall(id string, resultKind codexCodeModeResultKind) {
-	if id == "" {
-		return
-	}
-	if st.codeModeShellCalls == nil {
-		st.codeModeShellCalls = map[string]codexCodeModeResultKind{}
-	}
-	st.codeModeShellCalls[id] = resultKind
-}
-
-func (st *codexState) forgetCodeModeShellCall(id string) {
-	delete(st.codeModeShellCalls, id)
-}
-
-func (st *codexState) takeCodeModeShellCall(id string) (codexCodeModeResultKind, bool) {
-	resultKind, ok := st.codeModeShellCalls[id]
-	delete(st.codeModeShellCalls, id)
-	return resultKind, ok
+func (st *codexState) resetCall(id string) {
+	delete(st.shellCallIDs, id)
+	delete(st.failedMCPCallIDs, id)
+	st.codeMode.forgetCall(id)
 }
 
 // Extract parses a Codex rollout file. It reads the whole artifact to stamp a
@@ -321,8 +309,13 @@ func (e CodexExtractor) mapResponseItem(res *Result, src Source, sha string, st 
 	case codexRIMessage:
 		e.emitMessage(res, src, sha, st, line, ts, &ri)
 	case codexRIFunctionCall:
+		st.resetCall(ri.CallID)
+		if ri.Name == codexToolWait && ri.Namespace == "" && st.codeMode.noteWait(ri.CallID, string(ri.Arguments)) {
+			return
+		}
 		e.emitFunctionCall(res, src, sha, st, line, ts, &ri)
 	case codexRILocalShellCall:
+		st.resetCall(ri.CallID)
 		ev := e.base(src, sha, st, line, ts, 0)
 		ev.Actor = model.ActorAssistant
 		ev.Confidence = model.ConfidenceHigh
@@ -334,8 +327,8 @@ func (e CodexExtractor) mapResponseItem(res *Result, src Source, sha string, st 
 		st.noteShellCall(ri.CallID)
 		res.Events = append(res.Events, ev)
 	case codexRICustomToolCall:
-		// A later custom call reusing a malformed call id owns its next output.
-		st.forgetCodeModeShellCall(ri.CallID)
+		// A new call owns a reused id and its next output.
+		st.resetCall(ri.CallID)
 		if ri.Name == codexToolApplyPatch {
 			e.emitApplyPatchCall(res, src, sha, st, line, ts, ri.Name, ri.CallID, string(ri.Input), "/payload/input")
 			return
@@ -350,8 +343,11 @@ func (e CodexExtractor) mapResponseItem(res *Result, src Source, sha string, st 
 				ev.EventType = model.EventCommandExec
 				ev.Command = call.command
 				ev.Evidence.JSONPointer = "/payload/input"
-				st.noteCodeModeShellCall(ri.CallID, call.resultKind)
+				st.codeMode.noteExec(ri.CallID, call.resultKind)
 				res.Events = append(res.Events, ev)
+				return
+			}
+			if st.codeMode.noteWriteStdinPoll(ri.CallID, string(ri.Input)) {
 				return
 			}
 		}
@@ -390,8 +386,9 @@ func (e CodexExtractor) mapResponseItem(res *Result, src Source, sha string, st 
 		ev.ToolCallID = ri.CallID
 		resultBody := decodeCodexOutput(ri.Output)
 		ev.Evidence.JSONPointer = "/payload/output"
-		// An output paired by call_id with the matching shell-call variant is a
-		// command.result. Other function/custom outputs stay tool.result.
+		// Outputs correlated to a shell call are command.result updates. Static
+		// code-mode calls may traverse internal wait/write_stdin calls; those are
+		// folded back into the original command identity.
 		//
 		// Legacy shell outputs persist only prose, so their exit status remains
 		// unset. Current code-mode outputs can carry the exec helper's structured
@@ -403,17 +400,24 @@ func (e CodexExtractor) mapResponseItem(res *Result, src Source, sha string, st 
 		// mapEventMsg stamps TagToolError on this tool.result when it records a
 		// failure. When the end-event already arrived (it preceded this output), the
 		// failure was recorded in state, so tag here too.
-		var codeModeResultKind codexCodeModeResultKind
+		var codeModeRef codexCodeModeResultRef
 		var codeModeResult bool
-		if ri.Type == codexRICustomToolCallOut {
-			codeModeResultKind, codeModeResult = st.takeCodeModeShellCall(ri.CallID)
+		switch ri.Type {
+		case codexRICustomToolCallOut:
+			codeModeRef, codeModeResult = st.codeMode.takeCustomCall(ri.CallID)
+		case codexRIFunctionCallOutput:
+			codeModeRef, codeModeResult = st.codeMode.takeWaitCall(ri.CallID)
 		}
-		if (ri.Type == codexRIFunctionCallOutput && st.isShellCall(ri.CallID)) ||
-			(ri.Type == codexRICustomToolCallOut && codeModeResult) {
+		shellResult := ri.Type == codexRIFunctionCallOutput && st.takeShellCall(ri.CallID)
+		if codeModeResult || shellResult {
 			ev.EventType = model.EventCommandResult
 			if codeModeResult {
 				ev.ToolName = codexToolExecCommand
-				outcome := decodeCodexCodeModeOutcome(ri.Output, codeModeResultKind)
+				outcome := st.codeMode.trackOutcome(codeModeRef, ri.Output)
+				if outcome.cellID != "" {
+					return
+				}
+				ev.ToolCallID = codeModeRef.commandCallID
 				resultBody = outcome.output
 				ev.ExitCode = outcome.exitCode
 				ev.DurationMs = outcome.durationMs
@@ -426,7 +430,7 @@ func (e CodexExtractor) mapResponseItem(res *Result, src Source, sha string, st 
 			}
 		} else {
 			ev.EventType = model.EventToolResult
-			if st.isFailedMCPCall(ri.CallID) {
+			if st.takeFailedMCPCall(ri.CallID) {
 				ev.Tags = append(ev.Tags, model.TagToolError)
 			}
 		}

--- a/internal/extract/codex_code_mode.go
+++ b/internal/extract/codex_code_mode.go
@@ -8,9 +8,11 @@ import (
 )
 
 // Codex code mode persists one JavaScript cell as a custom tool call. Promote
-// only the common, unambiguous shape whose first operation is one static shell
-// call; arbitrary or compound programs stay generic tool.call events.
-var codexCodeModeExecPrefix = regexp.MustCompile(`^const[[:space:]]+([A-Za-z_$][A-Za-z0-9_$]*)[[:space:]]*=[[:space:]]*await[[:space:]]+tools\.exec_command[[:space:]]*\([[:space:]]*`)
+// only common, unambiguous static calls; arbitrary programs stay generic.
+var (
+	codexCodeModeExecPrefix       = regexp.MustCompile(`^const[[:space:]]+([A-Za-z_$][A-Za-z0-9_$]*)[[:space:]]*=[[:space:]]*await[[:space:]]+tools\.exec_command[[:space:]]*\([[:space:]]*`)
+	codexCodeModeWriteStdinPrefix = regexp.MustCompile(`^const[[:space:]]+([A-Za-z_$][A-Za-z0-9_$]*)[[:space:]]*=[[:space:]]*await[[:space:]]+tools\.write_stdin[[:space:]]*\([[:space:]]*`)
+)
 
 const codexCodeModeStringToken = "<string>"
 
@@ -31,8 +33,24 @@ type codexCodeModeOutcome struct {
 	output     string
 	exitCode   *int
 	durationMs *int64
+	cellID     string
+	sessionID  string
 	toolError  bool
 	recognized bool
+}
+
+type codexCodeModeResultRef struct {
+	commandCallID string
+	resultKind    codexCodeModeResultKind
+	sessionID     string
+	sessionPoll   bool
+}
+
+type codexCodeModeTracker struct {
+	customCalls map[string]codexCodeModeResultRef
+	waitCalls   map[string]codexCodeModeResultRef
+	cells       map[string]codexCodeModeResultRef
+	sessions    map[string]codexCodeModeResultRef
 }
 
 func codexCodeModeExecCommand(input string) (string, bool) {
@@ -41,28 +59,55 @@ func codexCodeModeExecCommand(input string) (string, bool) {
 }
 
 func parseCodexCodeModeExec(input string) (codexCodeModeExec, bool) {
+	args, resultKind, ok := parseCodexCodeModeStaticCall(input, codexCodeModeExecPrefix)
+	if !ok {
+		return codexCodeModeExec{}, false
+	}
+	command, ok := args["cmd"].(string)
+	if !ok || strings.TrimSpace(command) == "" {
+		return codexCodeModeExec{}, false
+	}
+	return codexCodeModeExec{command: command, resultKind: resultKind}, true
+}
+
+func parseCodexCodeModeWriteStdinPoll(input string) (sessionID string, resultKind codexCodeModeResultKind, ok bool) {
+	args, resultKind, ok := parseCodexCodeModeStaticCall(input, codexCodeModeWriteStdinPrefix)
+	if !ok || resultKind == codexCodeModeResultNone {
+		return "", codexCodeModeResultNone, false
+	}
+	if chars, exists := args["chars"]; exists {
+		text, isString := chars.(string)
+		if !isString || text != "" {
+			return "", codexCodeModeResultNone, false
+		}
+	}
+	sessionID, ok = codexCodeModeStaticID(args["session_id"])
+	return sessionID, resultKind, ok
+}
+
+func parseCodexCodeModeStaticCall(input string, prefix *regexp.Regexp) (map[string]any, codexCodeModeResultKind, bool) {
 	s := strings.TrimSpace(input)
 	if strings.HasPrefix(s, "// @exec:") {
 		newline := strings.IndexByte(s, '\n')
 		if newline < 0 {
-			return codexCodeModeExec{}, false
+			return nil, codexCodeModeResultNone, false
 		}
 		s = strings.TrimSpace(s[newline+1:])
 	}
 
-	match := codexCodeModeExecPrefix.FindStringSubmatchIndex(s)
+	match := prefix.FindStringSubmatchIndex(s)
 	if match == nil || !isCodexCodeModeBindingName(s[match[2]:match[3]]) {
-		return codexCodeModeExec{}, false
+		return nil, codexCodeModeResultNone, false
 	}
 	resultName := s[match[2]:match[3]]
 
-	command, end, ok := parseCodexCodeModeExecArgs(s, match[1])
+	args, end, ok := parseCodexCodeModeArgs(s, match[1])
 	if !ok {
-		return codexCodeModeExec{}, false
+		return nil, codexCodeModeResultNone, false
 	}
 	end = skipASCIIWhitespace(s, end)
 	if end >= len(s) || s[end] != ')' {
-		return codexCodeModeExec{}, false
+		return nil, codexCodeModeResultNone, false
 	}
 	end++
 	var lineBreak bool
@@ -73,16 +118,16 @@ func parseCodexCodeModeExec(input string) (codexCodeModeExec, bool) {
 		separated = true
 	}
 	if skipASCIIWhitespace(s, end) < len(s) && !separated {
-		return codexCodeModeExec{}, false
+		return nil, codexCodeModeResultNone, false
 	}
 
 	// Accept only an empty tail or the common result-forwarding forms. Any other
 	// JavaScript may contain another operation or alter the meaning of the output.
 	resultKind, ok := codexCodeModeResultTail(s[end:], resultName)
 	if !ok {
-		return codexCodeModeExec{}, false
+		return nil, codexCodeModeResultNone, false
 	}
-	return codexCodeModeExec{command: command, resultKind: resultKind}, true
+	return args, resultKind, true
 }
 
 func codexCodeModeResultTail(s, resultName string) (codexCodeModeResultKind, bool) {
@@ -117,7 +162,7 @@ func codexCodeModeResultTail(s, resultName string) (codexCodeModeResultKind, boo
 var (
 	codexCodeModeOutputEnvelope  = regexp.MustCompile(`^Script completed\nWall time [0-9]+(?:\.[0-9]+)? seconds\nOutput:\n$`)
 	codexCodeModeFailedEnvelope  = regexp.MustCompile(`^Script failed\nWall time [0-9]+(?:\.[0-9]+)? seconds\nOutput:\n$`)
-	codexCodeModeRunningEnvelope = regexp.MustCompile(`^Script running with cell ID [^\n]+\nWall time [0-9]+(?:\.[0-9]+)? seconds\nOutput:\n`)
+	codexCodeModeRunningEnvelope = regexp.MustCompile(`^Script running with cell ID ([^\n]+)\nWall time [0-9]+(?:\.[0-9]+)? seconds\nOutput:\n$`)
 )
 
 func decodeCodexCodeModeOutput(raw json.RawMessage) (string, bool) {
@@ -139,6 +184,13 @@ func decodeCodexCodeModeOutcome(raw json.RawMessage, kind codexCodeModeResultKin
 		output:     decodeCodexOutput(raw),
 		recognized: kind != codexCodeModeResultObject,
 	}
+	// A running cell is a plain control envelope. Completed command stdout is
+	// carried in separate content items, so it cannot impersonate this shape.
+	if cellID, ok := codexCodeModeRunningCellID(raw); ok {
+		outcome.cellID = cellID
+		outcome.recognized = true
+		return outcome
+	}
 	if body, ok := decodeCodexCodeModeEnvelope(raw, codexCodeModeFailedEnvelope); ok {
 		outcome.output = body
 		outcome.toolError = true
@@ -151,47 +203,205 @@ func decodeCodexCodeModeOutcome(raw json.RawMessage, kind codexCodeModeResultKin
 	if kind != codexCodeModeResultObject {
 		return outcome
 	}
-	if isCodexCodeModeRunningOutput(raw) {
-		outcome.recognized = true
-		return outcome
-	}
 
-	body, exitCode, durationMs, ok := decodeCodexCodeModeResultObject(raw)
+	body, exitCode, durationMs, sessionID, ok := decodeCodexCodeModeResultObject(raw)
 	if !ok {
 		return outcome
 	}
 	outcome.output = body
 	outcome.exitCode = exitCode
 	outcome.durationMs = durationMs
+	outcome.sessionID = sessionID
 	outcome.toolError = exitCode != nil && *exitCode != 0
 	outcome.recognized = true
 	return outcome
 }
 
-func decodeCodexCodeModeResultObject(raw json.RawMessage) (output string, exitCode *int, durationMs *int64, ok bool) {
+func decodeCodexCodeModeResultObject(raw json.RawMessage) (output string, exitCode *int, durationMs *int64, sessionID string, ok bool) {
 	body, ok := decodeCodexCodeModeOutput(raw)
 	if !ok {
-		return "", nil, nil, false
+		return "", nil, nil, "", false
 	}
 	var result struct {
-		ExitCode        *int     `json:"exit_code"`
-		Output          *string  `json:"output"`
-		WallTimeSeconds *float64 `json:"wall_time_seconds"`
+		ExitCode        *int            `json:"exit_code"`
+		Output          *string         `json:"output"`
+		SessionID       json.RawMessage `json:"session_id"`
+		WallTimeSeconds *float64        `json:"wall_time_seconds"`
 	}
 	if json.Unmarshal([]byte(body), &result) != nil || result.Output == nil {
-		return "", nil, nil, false
+		return "", nil, nil, "", false
+	}
+	if len(result.SessionID) > 0 && string(result.SessionID) != "null" {
+		var valid bool
+		sessionID, valid = codexCodeModeRawID(result.SessionID)
+		if !valid {
+			return "", nil, nil, "", false
+		}
 	}
 	if result.ExitCode != nil && result.WallTimeSeconds != nil &&
 		*result.WallTimeSeconds >= 0 && *result.WallTimeSeconds < float64(math.MaxInt64/1000) {
 		milliseconds := int64(math.Round(*result.WallTimeSeconds * 1000))
 		durationMs = &milliseconds
 	}
-	return *result.Output, result.ExitCode, durationMs, true
+	return *result.Output, result.ExitCode, durationMs, sessionID, true
 }
 
-func isCodexCodeModeRunningOutput(raw json.RawMessage) bool {
+func codexCodeModeRawID(raw json.RawMessage) (string, bool) {
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	decoder.UseNumber()
+	var value any
+	if decoder.Decode(&value) != nil {
+		return "", false
+	}
+	return codexCodeModeStaticID(value)
+}
+
+func codexCodeModeRunningCellID(raw json.RawMessage) (string, bool) {
 	var output string
-	return json.Unmarshal(raw, &output) == nil && codexCodeModeRunningEnvelope.MatchString(output)
+	if json.Unmarshal(raw, &output) != nil {
+		return "", false
+	}
+	match := codexCodeModeRunningEnvelope.FindStringSubmatch(output)
+	if len(match) != 2 || strings.TrimSpace(match[1]) == "" {
+		return "", false
+	}
+	return match[1], true
+}
+
+func (t *codexCodeModeTracker) noteExec(callID string, resultKind codexCodeModeResultKind) {
+	if callID == "" {
+		return
+	}
+	if t.customCalls == nil {
+		t.customCalls = make(map[string]codexCodeModeResultRef)
+	}
+	t.customCalls[callID] = codexCodeModeResultRef{
+		commandCallID: callID,
+		resultKind:    resultKind,
+	}
+}
+
+func (t *codexCodeModeTracker) noteWriteStdinPoll(callID, input string) bool {
+	if callID == "" {
+		return false
+	}
+	sessionID, resultKind, ok := parseCodexCodeModeWriteStdinPoll(input)
+	if !ok {
+		return false
+	}
+	ref, ok := t.sessions[sessionID]
+	if !ok {
+		return false
+	}
+	ref.resultKind = resultKind
+	ref.sessionPoll = true
+	ref.sessionID = sessionID
+	if t.customCalls == nil {
+		t.customCalls = make(map[string]codexCodeModeResultRef)
+	}
+	t.customCalls[callID] = ref
+	return true
+}
+
+func (t *codexCodeModeTracker) noteWait(callID, arguments string) bool {
+	if callID == "" {
+		return false
+	}
+	cellID, terminate, ok := codexCodeModeWaitCellID(arguments)
+	if !ok {
+		return false
+	}
+	if terminate {
+		delete(t.cells, cellID)
+		return false
+	}
+	ref, ok := t.cells[cellID]
+	if !ok {
+		return false
+	}
+	delete(t.cells, cellID)
+	if t.waitCalls == nil {
+		t.waitCalls = make(map[string]codexCodeModeResultRef)
+	}
+	t.waitCalls[callID] = ref
+	return true
+}
+
+func (t *codexCodeModeTracker) forgetCall(callID string) {
+	delete(t.customCalls, callID)
+	delete(t.waitCalls, callID)
+	forgetCodexCodeModeOwner(t.customCalls, callID)
+	forgetCodexCodeModeOwner(t.waitCalls, callID)
+	forgetCodexCodeModeOwner(t.cells, callID)
+	forgetCodexCodeModeOwner(t.sessions, callID)
+}
+
+func forgetCodexCodeModeOwner(entries map[string]codexCodeModeResultRef, callID string) {
+	for id, ref := range entries {
+		if ref.commandCallID == callID {
+			delete(entries, id)
+		}
+	}
+}
+
+func (t *codexCodeModeTracker) takeCustomCall(callID string) (codexCodeModeResultRef, bool) {
+	ref, ok := t.customCalls[callID]
+	delete(t.customCalls, callID)
+	return ref, ok
+}
+
+func (t *codexCodeModeTracker) takeWaitCall(callID string) (codexCodeModeResultRef, bool) {
+	ref, ok := t.waitCalls[callID]
+	delete(t.waitCalls, callID)
+	return ref, ok
+}
+
+func (t *codexCodeModeTracker) trackOutcome(ref codexCodeModeResultRef, raw json.RawMessage) codexCodeModeOutcome {
+	outcome := decodeCodexCodeModeOutcome(raw, ref.resultKind)
+	if outcome.cellID != "" {
+		if t.cells == nil {
+			t.cells = make(map[string]codexCodeModeResultRef)
+		}
+		t.cells[outcome.cellID] = ref
+	}
+	if outcome.sessionID != "" {
+		if ref.sessionID != "" && ref.sessionID != outcome.sessionID {
+			delete(t.sessions, ref.sessionID)
+		}
+		if t.sessions == nil {
+			t.sessions = make(map[string]codexCodeModeResultRef)
+		}
+		next := ref
+		next.sessionPoll = true
+		next.sessionID = outcome.sessionID
+		t.sessions[outcome.sessionID] = next
+	}
+	if outcome.exitCode != nil || outcome.toolError {
+		if ref.sessionID != "" {
+			delete(t.sessions, ref.sessionID)
+		}
+		if outcome.sessionID != "" {
+			delete(t.sessions, outcome.sessionID)
+		}
+	}
+	if ref.sessionPoll {
+		outcome.durationMs = nil
+	}
+	return outcome
+}
+
+func codexCodeModeWaitCellID(arguments string) (cellID string, terminate bool, ok bool) {
+	var args map[string]json.RawMessage
+	if json.Unmarshal([]byte(arguments), &args) != nil {
+		return "", false, false
+	}
+	if raw, exists := args["terminate"]; exists {
+		if json.Unmarshal(raw, &terminate) != nil {
+			return "", false, false
+		}
+	}
+	cellID, ok = codexCodeModeRawID(args["cell_id"])
+	return cellID, terminate, ok
 }
 
 func codexCodeModeTailTokens(s string) ([]string, bool) {
@@ -247,34 +457,33 @@ func codexCodeModeTokensEqual(got []string, want ...string) bool {
 	return true
 }
 
-func parseCodexCodeModeExecArgs(s string, start int) (string, int, bool) {
+func parseCodexCodeModeArgs(s string, start int) (map[string]any, int, bool) {
 	i := skipASCIIWhitespace(s, start)
 	if i >= len(s) || s[i] != '{' {
-		return "", 0, false
+		return nil, 0, false
 	}
 	i++
 
-	var command string
-	seenCommand := false
+	args := make(map[string]any)
 	for {
 		i = skipASCIIWhitespace(s, i)
 		if i >= len(s) {
-			return "", 0, false
+			return nil, 0, false
 		}
 		if s[i] == '}' {
-			if !seenCommand || strings.TrimSpace(command) == "" {
-				return "", 0, false
-			}
-			return command, i + 1, true
+			return args, i + 1, true
 		}
 
 		key, next, ok := parseCodexCodeModePropertyName(s, i)
 		if !ok {
-			return "", 0, false
+			return nil, 0, false
+		}
+		if _, duplicate := args[key]; duplicate {
+			return nil, 0, false
 		}
 		i = skipASCIIWhitespace(s, next)
 		if i >= len(s) || s[i] != ':' {
-			return "", 0, false
+			return nil, 0, false
 		}
 		i = skipASCIIWhitespace(s, i+1)
 
@@ -282,43 +491,41 @@ func parseCodexCodeModeExecArgs(s string, start int) (string, int, bool) {
 		decoder := json.NewDecoder(strings.NewReader(s[i:]))
 		decoder.UseNumber()
 		if err := decoder.Decode(&value); err != nil || decoder.InputOffset() <= 0 {
-			return "", 0, false
+			return nil, 0, false
 		}
 		i += int(decoder.InputOffset())
-		if key == "cmd" {
-			if seenCommand {
-				return "", 0, false
-			}
-			var isString bool
-			command, isString = value.(string)
-			if !isString {
-				return "", 0, false
-			}
-			seenCommand = true
-		}
+		args[key] = value
 
 		i = skipASCIIWhitespace(s, i)
 		if i >= len(s) {
-			return "", 0, false
+			return nil, 0, false
 		}
 		switch s[i] {
 		case '}':
-			if !seenCommand || strings.TrimSpace(command) == "" {
-				return "", 0, false
-			}
-			return command, i + 1, true
+			return args, i + 1, true
 		case ',':
 			i++
 			if next := skipASCIIWhitespace(s, i); next < len(s) && s[next] == '}' {
-				if !seenCommand || strings.TrimSpace(command) == "" {
-					return "", 0, false
-				}
-				return command, next + 1, true
+				return args, next + 1, true
 			}
 		default:
-			return "", 0, false
+			return nil, 0, false
 		}
 	}
+}
+
+func codexCodeModeStaticID(value any) (string, bool) {
+	switch value := value.(type) {
+	case json.Number:
+		if _, err := value.Int64(); err == nil {
+			return value.String(), true
+		}
+	case string:
+		if strings.TrimSpace(value) != "" {
+			return value, true
+		}
+	}
+	return "", false
 }
 
 func parseCodexCodeModePropertyName(s string, start int) (string, int, bool) {

--- a/internal/extract/codex_code_mode_test.go
+++ b/internal/extract/codex_code_mode_test.go
@@ -1,6 +1,8 @@
 package extract
 
 import (
+	"encoding/json"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -64,7 +66,7 @@ func TestExtractCodexCodeModeRunningResultHasNoFinalOutcome(t *testing.T) {
 	}
 }
 
-func TestExtractCodexCodeModeRunningEnvelopeHasNoFinalOutcome(t *testing.T) {
+func TestExtractCodexCodeModeRunningEnvelopeDefersResult(t *testing.T) {
 	input := `const r = await tools.exec_command({cmd:"sleep 10"}); text(r);`
 	body := strings.Join([]string{
 		`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"e1","input":` + jsonString(input) + `}}`,
@@ -72,13 +74,263 @@ func TestExtractCodexCodeModeRunningEnvelopeHasNoFinalOutcome(t *testing.T) {
 	}, "\n")
 	res := extractCodex(t, body)
 	acts := activityEvents(res.Events)
-	if len(acts) != 2 {
-		t.Fatalf("got %d activity events, want 2: %s", len(acts), dumpEvents(acts))
+	if len(acts) != 1 {
+		t.Fatalf("got %d activity events, want only command.exec: %s", len(acts), dumpEvents(acts))
 	}
-	result := acts[1]
-	if result.EventType != model.EventCommandResult || result.ExitCode != nil ||
-		result.DurationMs != nil || hasTag(result.Tags, model.TagToolError) || len(res.Diagnostics) != 0 {
-		t.Fatalf("result = %+v, diagnostics = %+v; want a non-final running result", result, res.Diagnostics)
+	if acts[0].EventType != model.EventCommandExec || len(res.Diagnostics) != 0 {
+		t.Fatalf("events = %s, diagnostics = %+v; want a deferred result", dumpEvents(acts), res.Diagnostics)
+	}
+}
+
+func TestExtractCodexCodeModeCompletedStdoutCannotStartCorrelation(t *testing.T) {
+	input := `const r = await tools.exec_command({cmd:"printf spoof"}); text(r.output);`
+	body := strings.Join([]string{
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"cmd1","input":` + jsonString(input) + `}}`,
+		`{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"cmd1","output":[{"type":"input_text","text":"Script completed\nWall time 0.1 seconds\nOutput:\n"},{"type":"input_text","text":"Script running with cell ID 18\nWall time 11.0 seconds\nOutput:\n"}]}}`,
+		`{"timestamp":"t3","type":"response_item","payload":{"type":"function_call","name":"wait","call_id":"wait1","arguments":"{\"cell_id\":\"18\"}"}}`,
+		`{"timestamp":"t4","type":"response_item","payload":{"type":"function_call_output","call_id":"wait1","output":"unrelated"}}`,
+	}, "\n")
+	acts := activityEvents(extractCodex(t, body).Events)
+	if len(acts) != 4 {
+		t.Fatalf("got %d activity events, want command/result + generic wait/result: %s", len(acts), dumpEvents(acts))
+	}
+	if acts[1].EventType != model.EventCommandResult || acts[2].EventType != model.EventToolCall ||
+		acts[2].ToolName != codexToolWait || acts[3].EventType != model.EventToolResult {
+		t.Fatalf("events = %s, raw command output must not create tracker state", dumpEvents(acts))
+	}
+}
+
+func TestExtractCodexCodeModeRunningCellCorrelation(t *testing.T) {
+	inputs := map[string]string{
+		"output forwarding": `const r = await tools.exec_command({cmd:"sleep 1"}); text(r.output);`,
+		"no forwarding":     `const r = await tools.exec_command({cmd:"sleep 1"});`,
+	}
+	for name, input := range inputs {
+		t.Run(name, func(t *testing.T) {
+			body := strings.Join([]string{
+				`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"cmd1","input":` + jsonString(input) + `}}`,
+				`{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"cmd1","output":"Script running with cell ID 18\nWall time 11.0 seconds\nOutput:\n"}}`,
+				`{"timestamp":"t3","type":"response_item","payload":{"type":"function_call","name":"wait","call_id":"wait1","arguments":"{\"cell_id\":\"18\"}"}}`,
+				`{"timestamp":"t4","type":"response_item","payload":{"type":"function_call_output","call_id":"wait1","output":[{"type":"input_text","text":"Script completed\nWall time 1.0 seconds\nOutput:\n"},{"type":"input_text","text":"done"}]}}`,
+			}, "\n")
+			acts := activityEvents(extractCodex(t, body).Events)
+			if len(acts) != 2 || acts[0].EventType != model.EventCommandExec ||
+				acts[1].EventType != model.EventCommandResult || acts[1].ToolCallID != "cmd1" ||
+				acts[1].ContentPreview != "done" {
+				t.Fatalf("events = %s, want one command with its correlated result", dumpEvents(acts))
+			}
+		})
+	}
+}
+
+func TestExtractCodexCodeModeOutputForwardingPollsKnownSession(t *testing.T) {
+	input := `const r = await tools.exec_command({cmd:"sleep 1"}); text(r);`
+	poll := `const r = await tools.write_stdin({session_id:7, chars:""}); text(r.output);`
+	body := strings.Join([]string{
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"cmd1","input":` + jsonString(input) + `}}`,
+		`{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"cmd1","output":[{"type":"input_text","text":"Script completed\nWall time 1.0 seconds\nOutput:\n"},{"type":"input_text","text":"{\"session_id\":7,\"output\":\"running\"}"}]}}`,
+		`{"timestamp":"t3","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"poll1","input":` + jsonString(poll) + `}}`,
+		`{"timestamp":"t4","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"poll1","output":[{"type":"input_text","text":"Script completed\nWall time 1.0 seconds\nOutput:\n"},{"type":"input_text","text":"done"}]}}`,
+	}, "\n")
+	acts := activityEvents(extractCodex(t, body).Events)
+	if len(acts) != 3 || acts[1].EventType != model.EventCommandResult ||
+		acts[2].EventType != model.EventCommandResult || acts[2].ToolCallID != "cmd1" ||
+		acts[2].ContentPreview != "done" {
+		t.Fatalf("events = %s, output-only poll must retain the original command", dumpEvents(acts))
+	}
+}
+
+func TestExtractCodexCodeModeDirectWaitPreservesDuration(t *testing.T) {
+	input := `const r = await tools.exec_command({cmd:"sleep 1"}); text(r);`
+	body := strings.Join([]string{
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"cmd1","input":` + jsonString(input) + `}}`,
+		`{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"cmd1","output":"Script running with cell ID 18\nWall time 11.0 seconds\nOutput:\n"}}`,
+		`{"timestamp":"t3","type":"response_item","payload":{"type":"function_call","name":"wait","call_id":"wait1","arguments":"{\"cell_id\":\"18\"}"}}`,
+		`{"timestamp":"t4","type":"response_item","payload":{"type":"function_call_output","call_id":"wait1","output":[{"type":"input_text","text":"Script completed\nWall time 1.0 seconds\nOutput:\n"},{"type":"input_text","text":"{\"exit_code\":0,\"wall_time_seconds\":12.25,\"output\":\"done\"}"}]}}`,
+	}, "\n")
+	acts := activityEvents(extractCodex(t, body).Events)
+	if len(acts) != 2 || acts[1].EventType != model.EventCommandResult || acts[1].ToolCallID != "cmd1" ||
+		acts[1].DurationMs == nil || *acts[1].DurationMs != 12250 {
+		t.Fatalf("events = %s, want direct wait to preserve total command duration", dumpEvents(acts))
+	}
+}
+
+func TestExtractCodexCodeModeUnsafeWaitsStayGeneric(t *testing.T) {
+	tests := map[string]string{
+		"namespaced": `"namespace":"mcp__demo",`,
+		"terminate":  ``,
+	}
+	for name, extra := range tests {
+		t.Run(name, func(t *testing.T) {
+			arguments := `{"cell_id":"18"}`
+			if name == "terminate" {
+				arguments = `{"cell_id":"18","terminate":true}`
+			}
+			input := `const r = await tools.exec_command({cmd:"sleep 60"}); text(r);`
+			rows := []string{
+				`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"cmd1","input":` + jsonString(input) + `}}`,
+				`{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"cmd1","output":"Script running with cell ID 18\nWall time 11.0 seconds\nOutput:\n"}}`,
+				`{"timestamp":"t3","type":"response_item","payload":{"type":"function_call","name":"wait",` + extra + `"call_id":"wait1","arguments":` + jsonString(arguments) + `}}`,
+				`{"timestamp":"t4","type":"response_item","payload":{"type":"function_call_output","call_id":"wait1","output":"stopped"}}`,
+			}
+			want := 3
+			if name == "terminate" {
+				rows = append(rows,
+					`{"timestamp":"t5","type":"response_item","payload":{"type":"function_call","name":"wait","call_id":"wait2","arguments":"{\"cell_id\":\"18\"}"}}`,
+					`{"timestamp":"t6","type":"response_item","payload":{"type":"function_call_output","call_id":"wait2","output":"late"}}`,
+				)
+				want = 5
+			}
+			body := strings.Join(rows, "\n")
+			acts := activityEvents(extractCodex(t, body).Events)
+			if len(acts) != want {
+				t.Fatalf("got %d events, want %d: %s", len(acts), want, dumpEvents(acts))
+			}
+			for i := 1; i < len(acts); i += 2 {
+				if acts[i].EventType != model.EventToolCall || acts[i+1].EventType != model.EventToolResult {
+					t.Fatalf("events = %s, want generic wait call/result pairs", dumpEvents(acts))
+				}
+			}
+		})
+	}
+}
+
+func TestExtractCodexCodeModeCallIDReuseDropsOldOwner(t *testing.T) {
+	input := `const r = await tools.exec_command({cmd:"sleep 60"}); text(r);`
+	body := strings.Join([]string{
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"cmd1","input":` + jsonString(input) + `}}`,
+		`{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"cmd1","output":"Script running with cell ID 18\nWall time 11.0 seconds\nOutput:\n"}}`,
+		`{"timestamp":"t3","type":"response_item","payload":{"type":"function_call","name":"wait","call_id":"same","arguments":"{\"cell_id\":\"18\"}"}}`,
+		`{"timestamp":"t4","type":"response_item","payload":{"type":"custom_tool_call","name":"other","call_id":"same","input":"{}"}}`,
+		`{"timestamp":"t5","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"same","output":"new owner"}}`,
+	}, "\n")
+	acts := activityEvents(extractCodex(t, body).Events)
+	if len(acts) != 3 || acts[1].EventType != model.EventToolCall || acts[2].EventType != model.EventToolResult {
+		t.Fatalf("events = %s, reused call id must not retain the old command owner", dumpEvents(acts))
+	}
+}
+
+func TestExtractCodexCodeModeLocalShellTakesReusedWaitID(t *testing.T) {
+	input := `const r = await tools.exec_command({cmd:"sleep 60"}); text(r);`
+	body := strings.Join([]string{
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"cmd1","input":` + jsonString(input) + `}}`,
+		`{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"cmd1","output":"Script running with cell ID 18\nWall time 11.0 seconds\nOutput:\n"}}`,
+		`{"timestamp":"t3","type":"response_item","payload":{"type":"function_call","name":"wait","call_id":"same","arguments":"{\"cell_id\":\"18\"}"}}`,
+		`{"timestamp":"t4","type":"response_item","payload":{"type":"local_shell_call","call_id":"same","action":{"type":"exec","command":["echo","new"]}}}`,
+		`{"timestamp":"t5","type":"response_item","payload":{"type":"function_call_output","call_id":"same","output":"new"}}`,
+	}, "\n")
+	acts := activityEvents(extractCodex(t, body).Events)
+	if len(acts) != 3 || acts[1].EventType != model.EventCommandExec || acts[1].ToolCallID != "same" ||
+		acts[2].EventType != model.EventCommandResult || acts[2].ToolCallID != "same" {
+		t.Fatalf("events = %s, local shell must replace the pending wait owner", dumpEvents(acts))
+	}
+}
+
+func TestExtractCodexCodeModeGenericFunctionTakesReusedShellID(t *testing.T) {
+	body := strings.Join([]string{
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"local_shell_call","call_id":"same","action":{"type":"exec","command":["echo","old"]}}}`,
+		`{"timestamp":"t2","type":"response_item","payload":{"type":"function_call","name":"other","call_id":"same","arguments":"{}"}}`,
+		`{"timestamp":"t3","type":"response_item","payload":{"type":"function_call_output","call_id":"same","output":"new owner"}}`,
+	}, "\n")
+	acts := activityEvents(extractCodex(t, body).Events)
+	if len(acts) != 3 || acts[1].EventType != model.EventToolCall || acts[2].EventType != model.EventToolResult {
+		t.Fatalf("events = %s, generic function must replace the shell owner", dumpEvents(acts))
+	}
+}
+
+func TestCodexCodeModeSessionOwnershipTransfers(t *testing.T) {
+	result := func(sessionID int) json.RawMessage {
+		return json.RawMessage(`[{"type":"input_text","text":"Script completed\nWall time 1.0 seconds\nOutput:\n"},{"type":"input_text","text":"{\"session_id\":` + strconv.Itoa(sessionID) + `,\"output\":\"running\"}"}]`)
+	}
+	poll := func(sessionID int) string {
+		return `const r = await tools.write_stdin({session_id:` + strconv.Itoa(sessionID) + `, chars:""}); text(r);`
+	}
+	var tracker codexCodeModeTracker
+	tracker.noteExec("cmd1", codexCodeModeResultObject)
+	ref, ok := tracker.takeCustomCall("cmd1")
+	if !ok {
+		t.Fatal("initial command owner missing")
+	}
+	tracker.trackOutcome(ref, result(1))
+	if !tracker.noteWriteStdinPoll("poll1", poll(1)) {
+		t.Fatal("first session was not tracked")
+	}
+	ref, ok = tracker.takeCustomCall("poll1")
+	if !ok {
+		t.Fatal("first poll owner missing")
+	}
+	tracker.trackOutcome(ref, result(2))
+	if tracker.noteWriteStdinPoll("stale", poll(1)) {
+		t.Fatal("old session retained ownership after transition")
+	}
+	if !tracker.noteWriteStdinPoll("current", poll(2)) {
+		t.Fatal("new session did not receive ownership")
+	}
+}
+
+func TestCodexCodeModeForgetCallDropsOwnedState(t *testing.T) {
+	owned := codexCodeModeResultRef{commandCallID: "owner"}
+	tracker := codexCodeModeTracker{
+		customCalls: map[string]codexCodeModeResultRef{"poll": owned},
+		waitCalls:   map[string]codexCodeModeResultRef{"wait": owned},
+		cells:       map[string]codexCodeModeResultRef{"cell": owned},
+		sessions:    map[string]codexCodeModeResultRef{"session": owned},
+	}
+	tracker.forgetCall("owner")
+	if len(tracker.customCalls) != 0 || len(tracker.waitCalls) != 0 ||
+		len(tracker.cells) != 0 || len(tracker.sessions) != 0 {
+		t.Fatalf("owned state survived call reuse: %+v", tracker)
+	}
+}
+
+func TestExtractCodexCodeModeLongRunningCommandCorrelation(t *testing.T) {
+	input := `const r = await tools.exec_command({cmd:"sleep 60"}); text(r);`
+	poll := `const r = await tools.write_stdin({session_id:25546, chars:"", yield_time_ms:30000}); text(r);`
+	body := strings.Join([]string{
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"cmd1","input":` + jsonString(input) + `}}`,
+		`{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"cmd1","output":"Script running with cell ID 18\nWall time 11.0 seconds\nOutput:\n"}}`,
+		`{"timestamp":"t3","type":"response_item","payload":{"type":"function_call","name":"wait","call_id":"wait1","arguments":"{\"cell_id\":\"18\"}"}}`,
+		`{"timestamp":"t4","type":"response_item","payload":{"type":"function_call_output","call_id":"wait1","output":"Script running with cell ID 18\nWall time 1.0 seconds\nOutput:\n"}}`,
+		`{"timestamp":"t5","type":"response_item","payload":{"type":"function_call","name":"wait","call_id":"wait2","arguments":"{\"cell_id\":\"18\"}"}}`,
+		`{"timestamp":"t6","type":"response_item","payload":{"type":"function_call_output","call_id":"wait2","output":[{"type":"input_text","text":"Script completed\nWall time 30.0 seconds\nOutput:\n"},{"type":"input_text","text":"{\"session_id\":25546,\"wall_time_seconds\":30,\"output\":\"still running\"}"}]}}`,
+		`{"timestamp":"t7","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"poll1","input":` + jsonString(poll) + `}}`,
+		`{"timestamp":"t8","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"poll1","output":"Script running with cell ID 19\nWall time 30.0 seconds\nOutput:\n"}}`,
+		`{"timestamp":"t9","type":"response_item","payload":{"type":"function_call","name":"wait","call_id":"wait3","arguments":"{\"cell_id\":\"19\"}"}}`,
+		`{"timestamp":"t10","type":"response_item","payload":{"type":"function_call_output","call_id":"wait3","output":[{"type":"input_text","text":"Script completed\nWall time 12.0 seconds\nOutput:\n"},{"type":"input_text","text":"{\"exit_code\":7,\"wall_time_seconds\":12,\"output\":\"failed\"}"}]}}`,
+	}, "\n")
+	res := extractCodex(t, body)
+	acts := activityEvents(res.Events)
+	if len(acts) != 3 {
+		t.Fatalf("got %d activity events, want command + two result updates: %s", len(acts), dumpEvents(acts))
+	}
+	call, running, final := acts[0], acts[1], acts[2]
+	if call.EventType != model.EventCommandExec || call.ToolCallID != "cmd1" || call.Command != "sleep 60" {
+		t.Fatalf("call = %+v, want original command.exec", call)
+	}
+	if running.EventType != model.EventCommandResult || running.ToolCallID != "cmd1" ||
+		running.ContentPreview != "still running" || running.ExitCode != nil || running.DurationMs != nil {
+		t.Fatalf("running result = %+v, want correlated non-terminal update", running)
+	}
+	if final.EventType != model.EventCommandResult || final.ToolCallID != "cmd1" ||
+		final.ContentPreview != "failed" || final.ExitCode == nil || *final.ExitCode != 7 ||
+		final.DurationMs != nil || !hasTag(final.Tags, model.TagToolError) {
+		t.Fatalf("final result = %+v, want correlated terminal failure", final)
+	}
+	if len(res.Diagnostics) != 0 {
+		t.Fatalf("diagnostics = %+v, want none", res.Diagnostics)
+	}
+}
+
+func TestExtractCodexCodeModeUnrelatedWaitAndInputStayGeneric(t *testing.T) {
+	poll := `const r = await tools.write_stdin({session_id:25546, chars:"x"}); text(r);`
+	body := strings.Join([]string{
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"function_call","name":"wait","call_id":"wait1","arguments":"{\"cell_id\":\"unknown\"}"}}`,
+		`{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"poll1","input":` + jsonString(poll) + `}}`,
+	}, "\n")
+	acts := activityEvents(extractCodex(t, body).Events)
+	if len(acts) != 2 || acts[0].EventType != model.EventToolCall || acts[0].ToolName != codexToolWait ||
+		acts[1].EventType != model.EventToolCall || acts[1].ToolName != codexToolCodeModeExec {
+		t.Fatalf("events = %s, want unrelated wait and interactive input as generic calls", dumpEvents(acts))
 	}
 }
 

--- a/internal/extract/codex_entry.go
+++ b/internal/extract/codex_entry.go
@@ -86,6 +86,7 @@ const (
 	codexToolWriteFile    = "create_file"
 	codexToolEditFile     = "edit_file"
 	codexToolCodeModeExec = "exec"
+	codexToolWait         = "wait"
 	codexToolUpdatePlan   = "update_plan"
 	codexToolSearch       = "tool_search"
 	codexToolImage        = "image_generation"

--- a/internal/extract/codex_test.go
+++ b/internal/extract/codex_test.go
@@ -803,6 +803,45 @@ func TestExtractCodexMCPToolFailureBeforeOutput(t *testing.T) {
 	}
 }
 
+func TestExtractCodexMCPDeferredFailureIsSingleUse(t *testing.T) {
+	body := strings.Join([]string{
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"mcp__db__query","call_id":"same","input":"SELECT 1"}}`,
+		`{"timestamp":"t2","type":"event_msg","payload":{"type":"mcp_tool_call_end","call_id":"same","result":{"Err":"timeout"}}}`,
+		`{"timestamp":"t3","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"same","output":"first"}}`,
+		`{"timestamp":"t4","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"same","output":"duplicate"}}`,
+	}, "\n")
+	acts := activityEvents(extractCodex(t, body).Events)
+
+	var results []model.Event
+	for _, ev := range acts {
+		if ev.EventType == model.EventToolResult && ev.ToolCallID == "same" {
+			results = append(results, ev)
+		}
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d tool results, want 2:\n%s", len(results), dumpEvents(acts))
+	}
+	if !hasTag(results[0].Tags, model.TagToolError) || hasTag(results[1].Tags, model.TagToolError) {
+		t.Errorf("deferred failure leaked past its first result: %+v", results)
+	}
+}
+
+func TestExtractCodexNewCallClearsDeferredMCPFailure(t *testing.T) {
+	body := strings.Join([]string{
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"mcp__db__query","call_id":"same","input":"SELECT 1"}}`,
+		`{"timestamp":"t2","type":"event_msg","payload":{"type":"mcp_tool_call_end","call_id":"same","result":{"Err":"timeout"}}}`,
+		`{"timestamp":"t3","type":"response_item","payload":{"type":"function_call","name":"lookup","call_id":"same","arguments":"{}"}}`,
+		`{"timestamp":"t4","type":"response_item","payload":{"type":"function_call_output","call_id":"same","output":"clean"}}`,
+	}, "\n")
+	acts := activityEvents(extractCodex(t, body).Events)
+
+	for _, ev := range acts {
+		if ev.EventType == model.EventToolResult && ev.ToolCallID == "same" && hasTag(ev.Tags, model.TagToolError) {
+			t.Fatalf("new call inherited a stale MCP failure: %+v", ev)
+		}
+	}
+}
+
 // A generic custom_tool_call_output must not become a command.result merely
 // because its id collides with a direct shell call. Variant-specific state keeps
 // it as a tool.result carrying the same id.

--- a/internal/extract/openclaw.go
+++ b/internal/extract/openclaw.go
@@ -52,9 +52,8 @@ type openClawState struct {
 	projectPath      string
 	currentTimestamp string
 	commandCalls     map[string]struct{}
-	// codexCodeModeCommandCalls records how an embedded Codex exec cell forwards
-	// its result. It remains separate from direct function-call correlation.
-	codexCodeModeCommandCalls map[string]codexCodeModeResultKind
+	// codexCodeMode keeps embedded Codex exec polling under one command identity.
+	codexCodeMode codexCodeModeTracker
 	// failedMCPCallIDs is the set of call_ids whose Codex-flavor mcp_tool_call_end
 	// recorded a structured failure BEFORE the matching custom_tool_call_output was
 	// emitted. The later output consults this so it still carries the tool-error
@@ -77,30 +76,17 @@ func (st *openClawState) noteCommandCall(id string) {
 	st.commandCalls[id] = struct{}{}
 }
 
-// isCommandCall reports whether a tool-call id was a recorded command call.
-func (st *openClawState) isCommandCall(id string) bool {
+// takeCommandCall consumes the command owner for a tool result.
+func (st *openClawState) takeCommandCall(id string) bool {
 	_, ok := st.commandCalls[id]
+	delete(st.commandCalls, id)
 	return ok
 }
 
-func (st *openClawState) noteCodexCodeModeCommandCall(id string, resultKind codexCodeModeResultKind) {
-	if id == "" {
-		return
-	}
-	if st.codexCodeModeCommandCalls == nil {
-		st.codexCodeModeCommandCalls = map[string]codexCodeModeResultKind{}
-	}
-	st.codexCodeModeCommandCalls[id] = resultKind
-}
-
-func (st *openClawState) forgetCodexCodeModeCommandCall(id string) {
-	delete(st.codexCodeModeCommandCalls, id)
-}
-
-func (st *openClawState) takeCodexCodeModeCommandCall(id string) (codexCodeModeResultKind, bool) {
-	resultKind, ok := st.codexCodeModeCommandCalls[id]
-	delete(st.codexCodeModeCommandCalls, id)
-	return resultKind, ok
+func (st *openClawState) resetCall(id string) {
+	delete(st.commandCalls, id)
+	delete(st.failedMCPCallIDs, id)
+	st.codexCodeMode.forgetCall(id)
 }
 
 // noteFailedMCPCall records a call_id whose mcp_tool_call_end reported a
@@ -116,9 +102,10 @@ func (st *openClawState) noteFailedMCPCall(id string) {
 	st.failedMCPCallIDs[id] = struct{}{}
 }
 
-// isFailedMCPCall reports whether call_id's mcp_tool_call_end reported failure.
-func (st *openClawState) isFailedMCPCall(id string) bool {
+// takeFailedMCPCall consumes a deferred MCP failure for a tool result.
+func (st *openClawState) takeFailedMCPCall(id string) bool {
 	_, ok := st.failedMCPCallIDs[id]
+	delete(st.failedMCPCallIDs, id)
 	return ok
 }
 
@@ -391,6 +378,7 @@ func (e OpenClawExtractor) emitNativeBashExecution(res *Result, src Source, sha 
 func (e OpenClawExtractor) emitNativeToolCall(res *Result, src Source, sha string, st *openClawState, line, block int, c *openClawBlock) {
 	args, argsField := c.nativeToolArgs()
 	callID := c.toolCallID()
+	st.resetCall(callID)
 	pointer := fmt.Sprintf("/message/content/%d", block)
 	if argsField != "" {
 		pointer += "/" + argsField
@@ -504,7 +492,7 @@ func (e OpenClawExtractor) emitNativeToolResult(res *Result, src Source, sha str
 	ev.ToolCallID = m.ToolCallID
 	ev.ToolName = m.ToolName
 	ev.Evidence.JSONPointer = "/message"
-	if st.isCommandCall(m.ToolCallID) {
+	if st.takeCommandCall(m.ToolCallID) {
 		ev.EventType = model.EventCommandResult
 		ev.ExitCode = openClawExitCode(m.Details)
 	} else {
@@ -578,7 +566,7 @@ func (e OpenClawExtractor) emitToolResult(res *Result, src Source, sha string, s
 	resultID := c.toolResultID()
 	ev.ToolCallID = resultID
 	ev.Evidence.JSONPointer = fmt.Sprintf("/message/content/%d", block)
-	if st.isCommandCall(resultID) {
+	if st.takeCommandCall(resultID) {
 		ev.EventType = model.EventCommandResult
 	} else {
 		ev.EventType = model.EventToolResult

--- a/internal/extract/openclaw_codex.go
+++ b/internal/extract/openclaw_codex.go
@@ -100,8 +100,13 @@ func (e OpenClawExtractor) mapCodexResponseItem(res *Result, src Source, sha str
 	case codexRIMessage:
 		e.emitCodexMessage(res, src, sha, st, line, &ri)
 	case codexRIFunctionCall:
+		st.resetCall(ri.CallID)
+		if ri.Name == codexToolWait && ri.Namespace == "" && st.codexCodeMode.noteWait(ri.CallID, string(ri.Arguments)) {
+			return
+		}
 		e.emitCodexFunctionCall(res, src, sha, st, line, &ri)
 	case codexRILocalShellCall:
+		st.resetCall(ri.CallID)
 		ev := e.base(src, sha, st, line, 0)
 		ev.Actor = model.ActorAssistant
 		ev.Confidence = model.ConfidenceHigh
@@ -119,19 +124,27 @@ func (e OpenClawExtractor) mapCodexResponseItem(res *Result, src Source, sha str
 		ev.ToolCallID = ri.CallID
 		ev.Evidence.JSONPointer = "/payload/output"
 		resultBody := decodeCodexOutput(ri.Output)
-		// An output paired with the matching shell-call variant is a
-		// command.result; every other output stays tool.result.
-		var codeModeResultKind codexCodeModeResultKind
+		// Outputs correlated to a shell call are command.result updates. Static
+		// code-mode calls may traverse internal wait/write_stdin calls; those are
+		// folded back into the original command identity.
+		var codeModeRef codexCodeModeResultRef
 		var codeModeResult bool
-		if ri.Type == codexRICustomToolCallOut {
-			codeModeResultKind, codeModeResult = st.takeCodexCodeModeCommandCall(ri.CallID)
+		switch ri.Type {
+		case codexRICustomToolCallOut:
+			codeModeRef, codeModeResult = st.codexCodeMode.takeCustomCall(ri.CallID)
+		case codexRIFunctionCallOutput:
+			codeModeRef, codeModeResult = st.codexCodeMode.takeWaitCall(ri.CallID)
 		}
-		if (ri.Type == codexRIFunctionCallOutput && st.isCommandCall(ri.CallID)) ||
-			(ri.Type == codexRICustomToolCallOut && codeModeResult) {
+		commandResult := ri.Type == codexRIFunctionCallOutput && st.takeCommandCall(ri.CallID)
+		if codeModeResult || commandResult {
 			ev.EventType = model.EventCommandResult
 			if codeModeResult {
 				ev.ToolName = codexToolExecCommand
-				outcome := decodeCodexCodeModeOutcome(ri.Output, codeModeResultKind)
+				outcome := st.codexCodeMode.trackOutcome(codeModeRef, ri.Output)
+				if outcome.cellID != "" {
+					return
+				}
+				ev.ToolCallID = codeModeRef.commandCallID
 				resultBody = outcome.output
 				ev.ExitCode = outcome.exitCode
 				ev.DurationMs = outcome.durationMs
@@ -147,7 +160,7 @@ func (e OpenClawExtractor) mapCodexResponseItem(res *Result, src Source, sha str
 			// An mcp_tool_call_end may have recorded this call's failure before its
 			// output landed (out-of-order); carry the structured tool-error forward so
 			// the late output is not a false negative, matching codex.go.
-			if st.isFailedMCPCall(ri.CallID) {
+			if st.takeFailedMCPCall(ri.CallID) {
 				ev.Tags = append(ev.Tags, model.TagToolError)
 			}
 		}
@@ -173,8 +186,8 @@ func (e OpenClawExtractor) mapCodexResponseItem(res *Result, src Source, sha str
 		ev.Evidence.JSONPointer = "/payload/action"
 		res.appendEvent(st, ev, true)
 	case codexRICustomToolCall:
-		// A later custom call reusing a malformed call id owns its next output.
-		st.forgetCodexCodeModeCommandCall(ri.CallID)
+		// A new call owns a reused id and its next output.
+		st.resetCall(ri.CallID)
 		if ri.Name == codexToolCodeModeExec {
 			if call, ok := parseCodexCodeModeExec(string(ri.Input)); ok {
 				ev := e.base(src, sha, st, line, 0)
@@ -185,8 +198,11 @@ func (e OpenClawExtractor) mapCodexResponseItem(res *Result, src Source, sha str
 				ev.EventType = model.EventCommandExec
 				ev.Command = call.command
 				ev.Evidence.JSONPointer = "/payload/input"
-				st.noteCodexCodeModeCommandCall(ri.CallID, call.resultKind)
+				st.codexCodeMode.noteExec(ri.CallID, call.resultKind)
 				res.appendEvent(st, ev, true)
+				return
+			}
+			if st.codexCodeMode.noteWriteStdinPoll(ri.CallID, string(ri.Input)) {
 				return
 			}
 		}

--- a/internal/extract/openclaw_test.go
+++ b/internal/extract/openclaw_test.go
@@ -857,6 +857,141 @@ func TestOpenClawEmbeddedCodexCodeModeParity(t *testing.T) {
 	assertOpenClawPointersResolve(t, res, lines)
 }
 
+func TestOpenClawEmbeddedCodexLongRunningCodeModeParity(t *testing.T) {
+	input := `const r = await tools.exec_command({cmd:"sleep 60"}); text(r);`
+	poll := `const r = await tools.write_stdin({session_id:25546, chars:""}); text(r);`
+	lines := []string{
+		`{"timestamp":"t","type":"session_meta","payload":{"id":"cx-code","cwd":"/w"}}`,
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"cmd1","input":` + jsonString(input) + `}}`,
+		`{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"cmd1","output":"Script running with cell ID 18\nWall time 11.0 seconds\nOutput:\n"}}`,
+		`{"timestamp":"t3","type":"response_item","payload":{"type":"function_call","name":"wait","call_id":"wait1","arguments":"{\"cell_id\":\"18\"}"}}`,
+		`{"timestamp":"t4","type":"response_item","payload":{"type":"function_call_output","call_id":"wait1","output":[{"type":"input_text","text":"Script completed\nWall time 30.0 seconds\nOutput:\n"},{"type":"input_text","text":"{\"session_id\":25546,\"output\":\"still running\"}"}]}}`,
+		`{"timestamp":"t5","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"poll1","input":` + jsonString(poll) + `}}`,
+		`{"timestamp":"t6","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"poll1","output":"Script running with cell ID 19\nWall time 30.0 seconds\nOutput:\n"}}`,
+		`{"timestamp":"t7","type":"response_item","payload":{"type":"function_call","name":"wait","call_id":"wait2","arguments":"{\"cell_id\":\"19\"}"}}`,
+		`{"timestamp":"t8","type":"response_item","payload":{"type":"function_call_output","call_id":"wait2","output":[{"type":"input_text","text":"Script completed\nWall time 12.0 seconds\nOutput:\n"},{"type":"input_text","text":"{\"exit_code\":0,\"wall_time_seconds\":12,\"output\":\"done\"}"}]}}`,
+	}
+	res := extractOpenClaw(t, strings.Join(lines, "\n"))
+	if len(res.Events) != 3 {
+		t.Fatalf("got %d events, want command + two result updates: %+v", len(res.Events), res.Events)
+	}
+	if res.Events[0].EventType != model.EventCommandExec || res.Events[0].ToolCallID != "cmd1" {
+		t.Fatalf("call = %+v, want original command.exec", res.Events[0])
+	}
+	for i, result := range res.Events[1:] {
+		if result.EventType != model.EventCommandResult || result.ToolCallID != "cmd1" || result.DurationMs != nil {
+			t.Fatalf("result %d = %+v, want correlated command.result", i, result)
+		}
+	}
+	if res.Events[1].ContentPreview != "still running" || res.Events[2].ContentPreview != "done" ||
+		res.Events[2].ExitCode == nil || *res.Events[2].ExitCode != 0 {
+		t.Fatalf("results = %+v, want running then successful terminal output", res.Events[1:])
+	}
+	assertOpenClawPointersResolve(t, res, lines)
+}
+
+func TestOpenClawEmbeddedCodexCodeModeCorrelationGuards(t *testing.T) {
+	run := func(t *testing.T, rows ...string) []model.Event {
+		t.Helper()
+		lines := append([]string{`{"timestamp":"t","type":"session_meta","payload":{"id":"cx-code","cwd":"/w"}}`}, rows...)
+		res := extractOpenClaw(t, strings.Join(lines, "\n"))
+		assertOpenClawPointersResolve(t, res, lines)
+		return res.Events
+	}
+
+	t.Run("completed stdout cannot mint a cell", func(t *testing.T) {
+		input := `const r = await tools.exec_command({cmd:"printf spoof"}); text(r.output);`
+		events := run(t,
+			`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"cmd1","input":`+jsonString(input)+`}}`,
+			`{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"cmd1","output":[{"type":"input_text","text":"Script completed\nWall time 0.1 seconds\nOutput:\n"},{"type":"input_text","text":"Script running with cell ID 18\nWall time 11.0 seconds\nOutput:\n"}]}}`,
+			`{"timestamp":"t3","type":"response_item","payload":{"type":"function_call","name":"wait","call_id":"wait1","arguments":"{\"cell_id\":\"18\"}"}}`,
+			`{"timestamp":"t4","type":"response_item","payload":{"type":"function_call_output","call_id":"wait1","output":"unrelated"}}`,
+		)
+		if len(events) != 4 || events[1].EventType != model.EventCommandResult ||
+			events[2].EventType != model.EventToolCall || events[3].EventType != model.EventToolResult {
+			t.Fatalf("events = %+v, raw output must not create tracker state", events)
+		}
+	})
+
+	for name, input := range map[string]string{
+		"output forwarding tracks a running cell": `const r = await tools.exec_command({cmd:"sleep 1"}); text(r.output);`,
+		"no forwarding tracks a running cell":     `const r = await tools.exec_command({cmd:"sleep 1"});`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			events := run(t,
+				`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"cmd1","input":`+jsonString(input)+`}}`,
+				`{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"cmd1","output":"Script running with cell ID 18\nWall time 11.0 seconds\nOutput:\n"}}`,
+				`{"timestamp":"t3","type":"response_item","payload":{"type":"function_call","name":"wait","call_id":"wait1","arguments":"{\"cell_id\":\"18\"}"}}`,
+				`{"timestamp":"t4","type":"response_item","payload":{"type":"function_call_output","call_id":"wait1","output":[{"type":"input_text","text":"Script completed\nWall time 1.0 seconds\nOutput:\n"},{"type":"input_text","text":"done"}]}}`,
+			)
+			if len(events) != 2 || events[0].EventType != model.EventCommandExec ||
+				events[1].EventType != model.EventCommandResult || events[1].ToolCallID != "cmd1" {
+				t.Fatalf("events = %+v, want one command with its correlated result", events)
+			}
+		})
+	}
+
+	t.Run("unsafe waits stay generic", func(t *testing.T) {
+		input := `const r = await tools.exec_command({cmd:"sleep 60"}); text(r);`
+		events := run(t,
+			`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"cmd1","input":`+jsonString(input)+`}}`,
+			`{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"cmd1","output":"Script running with cell ID 18\nWall time 11.0 seconds\nOutput:\n"}}`,
+			`{"timestamp":"t3","type":"response_item","payload":{"type":"function_call","name":"wait","namespace":"mcp__demo","call_id":"mcp1","arguments":"{\"cell_id\":\"18\"}"}}`,
+			`{"timestamp":"t4","type":"response_item","payload":{"type":"function_call_output","call_id":"mcp1","output":"mcp result"}}`,
+			`{"timestamp":"t5","type":"response_item","payload":{"type":"function_call","name":"wait","call_id":"stop1","arguments":"{\"cell_id\":\"18\",\"terminate\":true}"}}`,
+			`{"timestamp":"t6","type":"response_item","payload":{"type":"function_call_output","call_id":"stop1","output":"stopped"}}`,
+		)
+		if len(events) != 5 {
+			t.Fatalf("got %d events, want command plus two generic call/result pairs: %+v", len(events), events)
+		}
+		for _, index := range []int{1, 3} {
+			if events[index].EventType != model.EventToolCall || events[index+1].EventType != model.EventToolResult {
+				t.Fatalf("events = %+v, unsafe waits must stay generic", events)
+			}
+		}
+	})
+
+	t.Run("reused call id drops old owner", func(t *testing.T) {
+		input := `const r = await tools.exec_command({cmd:"sleep 60"}); text(r);`
+		events := run(t,
+			`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"cmd1","input":`+jsonString(input)+`}}`,
+			`{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"cmd1","output":"Script running with cell ID 18\nWall time 11.0 seconds\nOutput:\n"}}`,
+			`{"timestamp":"t3","type":"response_item","payload":{"type":"function_call","name":"wait","call_id":"same","arguments":"{\"cell_id\":\"18\"}"}}`,
+			`{"timestamp":"t4","type":"response_item","payload":{"type":"custom_tool_call","name":"other","call_id":"same","input":"{}"}}`,
+			`{"timestamp":"t5","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"same","output":"new owner"}}`,
+		)
+		if len(events) != 3 || events[1].EventType != model.EventToolCall || events[2].EventType != model.EventToolResult {
+			t.Fatalf("events = %+v, reused call id must not retain old command ownership", events)
+		}
+	})
+
+	t.Run("local shell takes reused wait id", func(t *testing.T) {
+		input := `const r = await tools.exec_command({cmd:"sleep 60"}); text(r);`
+		events := run(t,
+			`{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","name":"exec","call_id":"cmd1","input":`+jsonString(input)+`}}`,
+			`{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"cmd1","output":"Script running with cell ID 18\nWall time 11.0 seconds\nOutput:\n"}}`,
+			`{"timestamp":"t3","type":"response_item","payload":{"type":"function_call","name":"wait","call_id":"same","arguments":"{\"cell_id\":\"18\"}"}}`,
+			`{"timestamp":"t4","type":"response_item","payload":{"type":"local_shell_call","call_id":"same","action":{"type":"exec","command":["echo","new"]}}}`,
+			`{"timestamp":"t5","type":"response_item","payload":{"type":"function_call_output","call_id":"same","output":"new"}}`,
+		)
+		if len(events) != 3 || events[1].EventType != model.EventCommandExec || events[1].ToolCallID != "same" ||
+			events[2].EventType != model.EventCommandResult || events[2].ToolCallID != "same" {
+			t.Fatalf("events = %+v, local shell must replace the pending wait owner", events)
+		}
+	})
+
+	t.Run("generic function takes reused shell id", func(t *testing.T) {
+		events := run(t,
+			`{"timestamp":"t1","type":"response_item","payload":{"type":"local_shell_call","call_id":"same","action":{"type":"exec","command":["echo","old"]}}}`,
+			`{"timestamp":"t2","type":"response_item","payload":{"type":"function_call","name":"other","call_id":"same","arguments":"{}"}}`,
+			`{"timestamp":"t3","type":"response_item","payload":{"type":"function_call_output","call_id":"same","output":"new owner"}}`,
+		)
+		if len(events) != 3 || events[1].EventType != model.EventToolCall || events[2].EventType != model.EventToolResult {
+			t.Fatalf("events = %+v, generic function must replace the shell owner", events)
+		}
+	})
+}
+
 func TestOpenClawEmbeddedCodexAmbiguousCodeModeStaysGeneric(t *testing.T) {
 	lines := []string{
 		`{"timestamp":"t","type":"session_meta","payload":{"id":"cx-code","cwd":"/w"}}`,
@@ -1141,6 +1276,49 @@ func TestOpenClawCodexEventMsgMcpToolErrorOutOfOrder(t *testing.T) {
 	}
 	if !hasTag(result.Tags, model.TagToolError) {
 		t.Errorf("out-of-order MCP failure must still tag the later tool.result: %+v", result.Tags)
+	}
+	assertOpenClawPointersResolve(t, res, lines)
+}
+
+func TestOpenClawCodexDeferredMCPFailureIsSingleUse(t *testing.T) {
+	lines := []string{
+		`{"timestamp":"t","type":"session_meta","payload":{"id":"cx-single","cwd":"/w"}}`,
+		`{"timestamp":"t","type":"response_item","payload":{"type":"custom_tool_call","name":"mcp__db__query","call_id":"same","input":"SELECT 1"}}`,
+		`{"timestamp":"t","type":"event_msg","payload":{"type":"mcp_tool_call_end","call_id":"same","result":{"Err":"timeout"}}}`,
+		`{"timestamp":"t","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"same","output":"first"}}`,
+		`{"timestamp":"t","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"same","output":"duplicate"}}`,
+	}
+	res := extractOpenClaw(t, strings.Join(lines, "\n"))
+
+	var results []model.Event
+	for _, ev := range res.Events {
+		if ev.EventType == model.EventToolResult && ev.ToolCallID == "same" {
+			results = append(results, ev)
+		}
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d tool results, want 2: %+v", len(results), res.Events)
+	}
+	if !hasTag(results[0].Tags, model.TagToolError) || hasTag(results[1].Tags, model.TagToolError) {
+		t.Errorf("deferred failure leaked past its first result: %+v", results)
+	}
+	assertOpenClawPointersResolve(t, res, lines)
+}
+
+func TestOpenClawCodexNewCallClearsDeferredMCPFailure(t *testing.T) {
+	lines := []string{
+		`{"timestamp":"t","type":"session_meta","payload":{"id":"cx-reuse","cwd":"/w"}}`,
+		`{"timestamp":"t","type":"response_item","payload":{"type":"custom_tool_call","name":"mcp__db__query","call_id":"same","input":"SELECT 1"}}`,
+		`{"timestamp":"t","type":"event_msg","payload":{"type":"mcp_tool_call_end","call_id":"same","result":{"Err":"timeout"}}}`,
+		`{"timestamp":"t","type":"response_item","payload":{"type":"function_call","name":"lookup","call_id":"same","arguments":"{}"}}`,
+		`{"timestamp":"t","type":"response_item","payload":{"type":"function_call_output","call_id":"same","output":"clean"}}`,
+	}
+	res := extractOpenClaw(t, strings.Join(lines, "\n"))
+
+	for _, ev := range res.Events {
+		if ev.EventType == model.EventToolResult && ev.ToolCallID == "same" && hasTag(ev.Tags, model.TagToolError) {
+			t.Fatalf("new call inherited a stale MCP failure: %+v", ev)
+		}
 	}
 	assertOpenClawPointersResolve(t, res, lines)
 }


### PR DESCRIPTION
## Summary
- correlate yielded `exec_command` calls with later `write_stdin` outcomes
- preserve normalized command identity across long-running sessions
- cover direct Codex and OpenClaw-wrapped records

Stacked on #8.

## Validation
- `go test ./internal/extract`