### PR TITLE
Fix Codex fork replay attribution

### DIFF
--- a/internal/extract/codex.go
+++ b/internal/extract/codex.go
@@ -34,11 +34,10 @@ const artifactCodexRollout = "codex_rollout"
 // that was rolled back. This mirrors the persistence policy in
 // codex-rs/rollout/src/policy.rs, where both layers are written to disk.
 //
-// Codex rollouts are append-only and event-ordered: unlike Gemini, the file is
-// not a mutable history that must be replayed into a canonical conversation, so
-// numbat walks it line by line like the Claude transcript parser. session_meta
-// and turn_context update the running session identity / working directory that
-// later events inherit but are not themselves emitted as events.
+// Codex rollouts are append-only and event-ordered. Forked rollouts may copy the
+// parent's history after the child session_meta; numbat skips that replay until
+// the first child task boundary. session_meta and turn_context update the
+// running identity and working directory but are not themselves emitted.
 //
 // The zero value is ready to use. maxBytes overrides the artifact size cap and
 // exists for tests; production callers use the zero value (the default cap).
@@ -56,6 +55,17 @@ func (CodexExtractor) Agent() string { return model.AgentCodex }
 type codexState struct {
 	sessionID   string
 	projectPath string
+	metaSeen    bool
+	// forkReplay suppresses copied parent records until a task_started UUID
+	// ordered after the child thread UUID marks the first child turn.
+	forkReplay    bool
+	forkSessionID [16]byte
+	// forkUnreadableLine records the first unreadable replay row so one
+	// diagnostic reports possible omission on recovery or at EOF.
+	forkUnreadableLine int
+	// forkUnorderedLine records a valid legacy task UUID. Current Codex uses
+	// ordered UUIDv7 turn IDs; a fork with only legacy IDs is ambiguous at EOF.
+	forkUnorderedLine int
 	// startIdx is the index of the synthetic session.start event in res.Events,
 	// valid only when started is set, so session.end can mirror its identity.
 	started  bool
@@ -160,7 +170,13 @@ func (e CodexExtractor) Extract(r io.Reader, src Source) (*Result, error) {
 	for line := 1; ; line++ {
 		raw, tooLong, err := readLine(br)
 		if tooLong {
-			res.diag(src.Path, line, "line exceeds size cap; skipped")
+			if st.forkReplay {
+				if st.forkUnreadableLine == 0 {
+					st.forkUnreadableLine = line
+				}
+			} else {
+				res.diag(src.Path, line, "line exceeds size cap; skipped")
+			}
 			if errors.Is(err, io.EOF) {
 				// A truncated final line still ends the stream: close the session
 				// so a capped rollout is not left with a start and no end.
@@ -190,6 +206,11 @@ func (e CodexExtractor) Extract(r io.Reader, src Source) (*Result, error) {
 // closing record to point a JSONPointer at, so the end carries artifact-level
 // evidence (path/line/hash) with an empty pointer.
 func (e CodexExtractor) emitSessionEnd(res *Result, src Source, sha string, st *codexState) {
+	if st.forkReplay && st.forkUnreadableLine > 0 {
+		res.diag(src.Path, st.forkUnreadableLine, "fork replay ended without a valid child task boundary after an unreadable record; child activity may be omitted")
+	} else if st.forkReplay && st.forkUnorderedLine > 0 {
+		res.diag(src.Path, st.forkUnorderedLine, "fork replay ended without an orderable child task boundary; child activity may be omitted")
+	}
 	if !st.started {
 		return
 	}
@@ -213,8 +234,37 @@ func (e CodexExtractor) emitSessionEnd(res *Result, src Source, sha string, st *
 func (e CodexExtractor) mapLine(res *Result, src Source, sha string, st *codexState, line int, raw []byte) {
 	var rl codexLine
 	if err := json.Unmarshal(raw, &rl); err != nil {
-		res.diag(src.Path, line, "malformed JSON line")
+		if st.forkReplay {
+			if st.forkUnreadableLine == 0 {
+				st.forkUnreadableLine = line
+			}
+		} else {
+			res.diag(src.Path, line, "malformed JSON line")
+		}
 		return
+	}
+	if st.forkReplay {
+		switch codexForkReplayBoundary(rl, st.forkSessionID) {
+		case codexForkBoundaryUnreadable:
+			if st.forkUnreadableLine == 0 {
+				st.forkUnreadableLine = line
+			}
+			return
+		case codexForkBoundaryUnordered:
+			if st.forkUnorderedLine == 0 {
+				st.forkUnorderedLine = line
+			}
+			return
+		case codexForkBoundaryChild:
+			// Continue below so the boundary line still updates parser state.
+		default:
+			return
+		}
+		if st.forkUnreadableLine > 0 {
+			res.diag(src.Path, st.forkUnreadableLine, "unreadable record while excluding copied fork history; activity before the child task boundary may be omitted")
+			st.forkUnreadableLine = 0
+		}
+		st.forkReplay = false
 	}
 	if rl.Timestamp != "" {
 		st.lastTimestamp = rl.Timestamp
@@ -251,11 +301,21 @@ func (e CodexExtractor) applySessionMeta(res *Result, src Source, sha string, st
 		res.diag(src.Path, line, "malformed session_meta payload")
 		return
 	}
+	firstMeta := !st.metaSeen
+	st.metaSeen = true
 	if st.sessionID == "" {
 		st.sessionID = meta.ID
 	}
 	if st.projectPath == "" {
 		st.projectPath = meta.Cwd
+	}
+	if firstMeta && meta.ForkedFromID != "" {
+		if id, ok := codexUUIDv7(meta.ID); ok {
+			st.forkReplay = true
+			st.forkSessionID = id
+		} else {
+			res.diag(src.Path, line, "forked session id is not UUIDv7; replay filtering disabled")
+		}
 	}
 	if st.started {
 		return
@@ -278,6 +338,39 @@ func (e CodexExtractor) applySessionMeta(res *Result, src Source, sha string, st
 	st.startIdx = len(res.Events)
 	st.started = true
 	res.Events = append(res.Events, ev)
+}
+
+type codexForkBoundary uint8
+
+const (
+	codexForkBoundaryNone codexForkBoundary = iota
+	codexForkBoundaryChild
+	codexForkBoundaryUnreadable
+	codexForkBoundaryUnordered
+)
+
+func codexForkReplayBoundary(line codexLine, sessionID [16]byte) codexForkBoundary {
+	if line.Type != codexTypeEventMsg {
+		return codexForkBoundaryNone
+	}
+	var event codexEventMsg
+	if json.Unmarshal(line.Payload, &event) != nil {
+		return codexForkBoundaryUnreadable
+	}
+	if event.Type != codexEMTaskStarted {
+		return codexForkBoundaryNone
+	}
+	turnID, ok := codexUUIDv7(event.TurnID)
+	if !ok {
+		if _, valid := codexUUID(event.TurnID); valid {
+			return codexForkBoundaryUnordered
+		}
+		return codexForkBoundaryUnreadable
+	}
+	if bytes.Compare(turnID[:], sessionID[:]) > 0 {
+		return codexForkBoundaryChild
+	}
+	return codexForkBoundaryNone
 }
 
 // applyTurnContext refreshes the working directory from a turn_context line.

--- a/internal/extract/codex_entry.go
+++ b/internal/extract/codex_entry.go
@@ -46,16 +46,15 @@ const (
 	codexRIContextCompaction = "context_compaction"
 )
 
-// Codex event_msg inner payload types numbat surfaces. The conversation and
-// tool timeline is taken from the response_item layer (the Responses API
-// ground truth); from event_msg numbat emits only records that have no
-// response_item equivalent and carry distinct forensic signal: a turn that was
-// aborted, and history that was rolled back. Everything else in event_msg
-// (user_message/agent_message/patch_apply_end/...) duplicates a response_item
-// record and is intentionally skipped to avoid double-counting the timeline.
+// Codex event_msg inner payload types numbat interprets. The conversation and
+// tool timeline comes from response_item; event_msg contributes only distinct
+// state changes, structured MCP failure, and the task boundary used to exclude
+// copied history from forked rollouts.
 const (
 	codexEMTurnAborted      = "turn_aborted"
 	codexEMThreadRolledBack = "thread_rolled_back"
+	// task_started is a fork replay boundary, not an emitted timeline event.
+	codexEMTaskStarted = "task_started"
 	// Persisted event_msg lifecycle/state transitions with NO response_item
 	// twin (verified against policy.rs should_persist_event_msg). Unlike
 	// user_message/agent_message/patch_apply_end — which duplicate a
@@ -107,15 +106,42 @@ type codexLine struct {
 	Payload   json.RawMessage `json:"payload"`
 }
 
-// codexSessionMeta is the first-line metadata: thread id, working directory,
-// and (flattened) git info. Only the fields numbat maps are decoded.
+// codexSessionMeta is the first-line metadata: thread identity, fork lineage,
+// working directory, and runtime details. Only fields numbat uses are decoded.
 type codexSessionMeta struct {
 	ID            string `json:"id"`
+	ForkedFromID  string `json:"forked_from_id"`
 	Timestamp     string `json:"timestamp"`
 	Cwd           string `json:"cwd"`
 	Originator    string `json:"originator"`
 	CliVersion    string `json:"cli_version"`
 	ModelProvider string `json:"model_provider"`
+}
+
+func codexUUID(id string) ([16]byte, bool) {
+	var uuid [16]byte
+	if len(id) != 36 || id[8] != '-' || id[13] != '-' || id[18] != '-' || id[23] != '-' {
+		return uuid, false
+	}
+	compact := id[:8] + id[9:13] + id[14:18] + id[19:23] + id[24:]
+	decoded, err := hex.DecodeString(compact)
+	if err != nil || len(decoded) != len(uuid) {
+		return uuid, false
+	}
+	copy(uuid[:], decoded)
+	version := uuid[6] >> 4
+	if uuid[8]&0xc0 != 0x80 || version == 0 || version > 8 {
+		return [16]byte{}, false
+	}
+	return uuid, true
+}
+
+func codexUUIDv7(id string) ([16]byte, bool) {
+	uuid, ok := codexUUID(id)
+	if !ok || uuid[6]>>4 != 7 {
+		return [16]byte{}, false
+	}
+	return uuid, true
 }
 
 // codexTurnContext carries the per-turn working directory. One turn_context is

--- a/internal/extract/codex_test.go
+++ b/internal/extract/codex_test.go
@@ -1288,3 +1288,147 @@ func TestExtractCodexFirstSessionMetaWins(t *testing.T) {
 		t.Errorf("session_id = %q, want first (the first session_meta is canonical)", acts[0].SessionID)
 	}
 }
+
+func TestExtractCodexForkSkipsCopiedHistory(t *testing.T) {
+	const childID = "019f84fe-e5e1-7f80-8745-493ccff96186"
+	body := strings.Join([]string{
+		`{"timestamp":"t1","type":"session_meta","payload":{"id":"` + childID + `","forked_from_id":"019f620e-730d-76e2-8204-f108cfe2f082","cwd":"/child"}}`,
+		`{"timestamp":"t2","type":"turn_context","payload":{"cwd":"/parent"}}`,
+		`not json`,
+		`{"timestamp":"t4","type":"event_msg","payload":{"type":"task_started","turn_id":"019f84f6-8114-7cd3-8ac7-47ad22f4fba9"}}`,
+		`{"timestamp":"t5","type":"response_item","payload":{"type":"message","role":"user","content":"parent prompt"}}`,
+		`{"timestamp":"t6","type":"response_item","payload":{"type":"function_call","name":"shell","call_id":"parent","arguments":"{\"command\":\"echo parent\"}"}}`,
+		`{"timestamp":"t7","type":"event_msg","payload":{"type":"task_started","turn_id":"` + childID + `"}}`,
+		`{"timestamp":"t8","type":"response_item","payload":{"type":"message","role":"assistant","content":"parent answer"}}`,
+		`{"timestamp":"t9","type":"event_msg","payload":{"type":"task_started","turn_id":"019f84ff-90e1-7f12-9b81-ed81048178c1"}}`,
+		`{"timestamp":"t10","type":"turn_context","payload":{"cwd":"/child/live"}}`,
+		`{"timestamp":"t11","type":"response_item","payload":{"type":"message","role":"user","content":"child prompt"}}`,
+		`{"timestamp":"t12","type":"response_item","payload":{"type":"function_call","name":"shell","call_id":"child","arguments":"{\"command\":\"echo child\"}"}}`,
+		`{"timestamp":"t13","type":"response_item","payload":{"type":"function_call_output","call_id":"child","output":"done"}}`,
+	}, "\n")
+	res := extractCodex(t, body)
+	acts := activityEvents(res.Events)
+	if len(acts) != 3 {
+		t.Fatalf("got %d activity events, want child prompt/command/result: %s", len(acts), dumpEvents(acts))
+	}
+	if acts[0].EventType != model.EventPromptUser || acts[0].ContentPreview != "child prompt" ||
+		acts[1].EventType != model.EventCommandExec || acts[1].Command != "echo child" ||
+		acts[2].EventType != model.EventCommandResult {
+		t.Fatalf("events = %s, copied parent activity was not excluded", dumpEvents(acts))
+	}
+	for _, ev := range acts {
+		if ev.SessionID != childID || ev.ProjectPath != "/child/live" {
+			t.Errorf("child event identity = session %q path %q", ev.SessionID, ev.ProjectPath)
+		}
+	}
+	if acts[0].Evidence.Line != 11 {
+		t.Errorf("first child event line = %d, want 11", acts[0].Evidence.Line)
+	}
+	if len(res.Diagnostics) != 1 || !strings.Contains(res.Diagnostics[0].Msg, "may be omitted") {
+		t.Errorf("diagnostics = %+v, want one bounded uncertainty warning", res.Diagnostics)
+	}
+}
+
+func TestExtractCodexForkWithoutChildTurnEmitsOnlyLifecycle(t *testing.T) {
+	body := strings.Join([]string{
+		`{"timestamp":"t1","type":"session_meta","payload":{"id":"019f84fe-e5e1-7f80-8745-493ccff96186","forked_from_id":"019f620e-730d-76e2-8204-f108cfe2f082","cwd":"/child"}}`,
+		`{"timestamp":"t2","type":"event_msg","payload":{"type":"task_started","turn_id":"019f84f6-8114-7cd3-8ac7-47ad22f4fba9"}}`,
+		`{"timestamp":"t3","type":"event_msg","payload":{"type":"task_started","turn_id":"ffffffff-ffff-4fff-bfff-ffffffffffff"}}`,
+		`{"timestamp":"t4","type":"response_item","payload":{"type":"message","role":"user","content":"copied"}}`,
+	}, "\n")
+	res := extractCodex(t, body)
+	if acts := activityEvents(res.Events); len(acts) != 0 {
+		t.Fatalf("copied history emitted activity: %s", dumpEvents(acts))
+	}
+	if len(res.Events) != 2 || res.Events[0].EventType != model.EventSessionStart ||
+		res.Events[1].EventType != model.EventSessionEnd || res.Events[1].Evidence.Line != 1 {
+		t.Fatalf("events = %s, want lifecycle bounded by child session_meta", dumpEvents(res.Events))
+	}
+	if len(res.Diagnostics) != 1 || !strings.Contains(res.Diagnostics[0].Msg, "orderable child task boundary") {
+		t.Errorf("diagnostics = %+v, want one legacy-boundary uncertainty warning", res.Diagnostics)
+	}
+}
+
+func TestExtractCodexForkIgnoresCopiedLegacyTaskID(t *testing.T) {
+	body := strings.Join([]string{
+		`{"timestamp":"t1","type":"session_meta","payload":{"id":"019f84fe-e5e1-7f80-8745-493ccff96186","forked_from_id":"019f620e-730d-76e2-8204-f108cfe2f082","cwd":"/child"}}`,
+		`{"timestamp":"t2","type":"event_msg","payload":{"type":"task_started","turn_id":"ffffffff-ffff-4fff-bfff-ffffffffffff"}}`,
+		`{"timestamp":"t3","type":"event_msg","payload":{"type":"task_started","turn_id":"019f84f6-8114-7cd3-8ac7-47ad22f4fba9"}}`,
+		`{"timestamp":"t4","type":"response_item","payload":{"type":"message","role":"user","content":"copied"}}`,
+		`{"timestamp":"t5","type":"event_msg","payload":{"type":"task_started","turn_id":"019f84ff-90e1-7f12-9b81-ed81048178c1"}}`,
+		`{"timestamp":"t6","type":"response_item","payload":{"type":"message","role":"user","content":"child"}}`,
+	}, "\n")
+	res := extractCodex(t, body)
+	acts := activityEvents(res.Events)
+	if len(acts) != 1 || acts[0].ContentPreview != "child" {
+		t.Fatalf("events = %s, copied legacy turn was not excluded", dumpEvents(acts))
+	}
+	if len(res.Diagnostics) != 0 {
+		t.Fatalf("copied legacy task ID produced diagnostics after an ordered child boundary: %+v", res.Diagnostics)
+	}
+}
+
+func TestExtractCodexForkWithLegacyIDFailsOpen(t *testing.T) {
+	body := strings.Join([]string{
+		`{"timestamp":"t1","type":"session_meta","payload":{"id":"legacy-child","forked_from_id":"legacy-parent","cwd":"/child"}}`,
+		`{"timestamp":"t2","type":"response_item","payload":{"type":"message","role":"user","content":"visible"}}`,
+	}, "\n")
+	res := extractCodex(t, body)
+	acts := activityEvents(res.Events)
+	if len(acts) != 1 || acts[0].ContentPreview != "visible" {
+		t.Fatalf("legacy fork did not fail open: %s", dumpEvents(acts))
+	}
+	if len(res.Diagnostics) != 1 || !strings.Contains(res.Diagnostics[0].Msg, "replay filtering disabled") {
+		t.Fatalf("diagnostics = %+v, want one replay-filter warning", res.Diagnostics)
+	}
+}
+
+func TestExtractCodexForkUnreadableBoundaryWarns(t *testing.T) {
+	const meta = `{"timestamp":"t1","type":"session_meta","payload":{"id":"019f84fe-e5e1-7f80-8745-493ccff96186","forked_from_id":"019f620e-730d-76e2-8204-f108cfe2f082","cwd":"/child"}}`
+	const boundary = `{"timestamp":"t3","type":"event_msg","payload":{"type":"task_started","turn_id":"019f84ff-90e1-7f12-9b81-ed81048178c1"}}`
+	for _, tc := range []struct {
+		name string
+		row  string
+	}{
+		{name: "malformed", row: `{"type":"event_msg","payload":{"type":"task_started"`},
+		{name: "missing turn id", row: `{"type":"event_msg","payload":{"type":"task_started"}}`},
+		{name: "unrecognized UUID version", row: `{"type":"event_msg","payload":{"type":"task_started","turn_id":"ffffffff-ffff-ffff-bfff-ffffffffffff"}}`},
+		{name: "overlong", row: strings.Repeat("x", maxLineSize+1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := strings.Join([]string{
+				meta,
+				tc.row,
+				boundary,
+				`{"timestamp":"t4","type":"response_item","payload":{"type":"message","role":"user","content":"child"}}`,
+			}, "\n")
+			res, err := CodexExtractor{maxBytes: len(body) + 1}.Extract(strings.NewReader(body), Source{Path: "/cases/fork.jsonl"})
+			if err != nil {
+				t.Fatalf("Extract returned error: %v", err)
+			}
+			acts := activityEvents(res.Events)
+			if len(acts) != 1 || acts[0].ContentPreview != "child" {
+				t.Fatalf("activity after the recovered boundary = %s", dumpEvents(acts))
+			}
+			if len(res.Diagnostics) != 1 || !strings.Contains(res.Diagnostics[0].Msg, "may be omitted") {
+				t.Fatalf("diagnostics = %+v, want one bounded omission warning", res.Diagnostics)
+			}
+		})
+	}
+
+	body := strings.Join([]string{
+		meta,
+		`{"type":"event_msg","payload":{"type":"task_started"}}`,
+		`{"timestamp":"t3","type":"response_item","payload":{"type":"message","role":"user","content":"unproven"}}`,
+	}, "\n")
+	res, err := CodexExtractor{maxBytes: len(body) + 1}.Extract(strings.NewReader(body), Source{Path: "/cases/fork.jsonl"})
+	if err != nil {
+		t.Fatalf("Extract returned error: %v", err)
+	}
+	if acts := activityEvents(res.Events); len(acts) != 0 {
+		t.Fatalf("activity after an unproven boundary was emitted: %s", dumpEvents(acts))
+	}
+	if len(res.Diagnostics) != 1 || !strings.Contains(res.Diagnostics[0].Msg, "child activity may be omitted") {
+		t.Fatalf("EOF diagnostics = %+v, want one bounded omission warning", res.Diagnostics)
+	}
+}


### PR DESCRIPTION
## Summary
- identify Codex fork boundaries from rollout metadata
- exclude copied parent history from child-session extraction
- retain post-fork events and correlation state

Stacked on #9.

## Validation
- `go test ./internal/extract`