### PR TITLE
Preserve Codex prompt and tool provenance

### DIFF
--- a/internal/extract/codex.go
+++ b/internal/extract/codex.go
@@ -25,14 +25,11 @@ const artifactCodexRollout = "codex_rollout"
 //
 // See codex-rs/protocol/src/protocol.rs for the persisted rollout variants.
 //
-// Two layers persist the same activity: a user prompt is written BOTH as a
-// response_item message AND as an event_msg user_message; an apply_patch shows
-// up as a function_call AND a patch_apply_end. To avoid double-counting the
-// timeline, numbat treats the response_item layer as canonical (it is the raw
-// model I/O) and emits from event_msg only the records with no response_item
-// equivalent that still carry forensic signal — a turn that aborted and history
-// that was rolled back. This mirrors the persistence policy in
-// codex-rs/rollout/src/policy.rs, where both layers are written to disk.
+// Tool activity and assistant messages come from response_item. Human prompts
+// prefer the explicit user_message lifecycle record (or paginated UserMessage
+// item), because Codex also stores injected context as role=user response
+// items. Older response-only artifacts retain that role-based fallback. Other
+// duplicate event_msg records are skipped.
 //
 // Codex rollouts are append-only and event-ordered. Forked rollouts may copy the
 // parent's history after the child session_meta; numbat skips that replay until
@@ -75,6 +72,15 @@ type codexState struct {
 	// the opener's timestamp and provenance.
 	lastTimestamp string
 	lastLine      int
+	// explicitUserMessages marks rollouts with user-facing lifecycle records.
+	// responsePromptIDs tracks the older response-item fallback so injected
+	// context can be discarded when an explicit source appears. A headered
+	// rollout holds its latest role=user item until its lifecycle record arrives,
+	// preserving the prompt if the artifact ends between writes.
+	explicitUserMessages  bool
+	userPromptExpected    bool
+	responsePromptIDs     map[string]struct{}
+	pendingResponsePrompt *model.Event
 	// shellCallIDs is the set of call_ids that were a shell command.exec (a
 	// local_shell_call or a shell/shell_command/exec_command function_call), so
 	// the paired function_call_output is promoted from tool.result to
@@ -180,6 +186,7 @@ func (e CodexExtractor) Extract(r io.Reader, src Source) (*Result, error) {
 			if errors.Is(err, io.EOF) {
 				// A truncated final line still ends the stream: close the session
 				// so a capped rollout is not left with a start and no end.
+				flushCodexResponsePrompt(res, st)
 				e.emitSessionEnd(res, src, sha, st)
 				return res, nil
 			}
@@ -191,6 +198,7 @@ func (e CodexExtractor) Extract(r io.Reader, src Source) (*Result, error) {
 		}
 		if err != nil {
 			if errors.Is(err, io.EOF) {
+				flushCodexResponsePrompt(res, st)
 				e.emitSessionEnd(res, src, sha, st)
 				return res, nil
 			}
@@ -265,6 +273,9 @@ func (e CodexExtractor) mapLine(res *Result, src Source, sha string, st *codexSt
 			st.forkUnreadableLine = 0
 		}
 		st.forkReplay = false
+	}
+	if st.pendingResponsePrompt != nil && !codexUserPromptContinuation(rl) {
+		st.pendingResponsePrompt = nil
 	}
 	if rl.Timestamp != "" {
 		st.lastTimestamp = rl.Timestamp
@@ -422,11 +433,11 @@ func (e CodexExtractor) mapResponseItem(res *Result, src Source, sha string, st 
 	case codexRICustomToolCall:
 		// A new call owns a reused id and its next output.
 		st.resetCall(ri.CallID)
-		if ri.Name == codexToolApplyPatch {
+		if ri.Namespace == "" && ri.Name == codexToolApplyPatch {
 			e.emitApplyPatchCall(res, src, sha, st, line, ts, ri.Name, ri.CallID, string(ri.Input), "/payload/input")
 			return
 		}
-		if ri.Name == codexToolCodeModeExec {
+		if ri.Namespace == "" && ri.Name == codexToolCodeModeExec {
 			if call, ok := parseCodexCodeModeExec(string(ri.Input)); ok {
 				ev := e.base(src, sha, st, line, ts, 0)
 				ev.Actor = model.ActorAssistant
@@ -630,6 +641,15 @@ func (e CodexExtractor) emitMessage(res *Result, src Source, sha string, st *cod
 	ev.Evidence.JSONPointer = "/payload/content"
 	switch ri.Role {
 	case "user":
+		if st.metaSeen || st.explicitUserMessages {
+			if !st.explicitUserMessages || st.userPromptExpected {
+				ev.EventType = model.EventPromptUser
+				ev.Actor = model.ActorUser
+				ev.Confidence = model.ConfidenceMedium
+				st.pendingResponsePrompt = &ev
+			}
+			return
+		}
 		ev.EventType = model.EventPromptUser
 		ev.Actor = model.ActorUser
 	case "assistant":
@@ -641,6 +661,12 @@ func (e CodexExtractor) emitMessage(res *Result, src Source, sha string, st *cod
 		return
 	}
 	res.Events = append(res.Events, ev)
+	if ri.Role == "user" {
+		if st.responsePromptIDs == nil {
+			st.responsePromptIDs = map[string]struct{}{}
+		}
+		st.responsePromptIDs[ev.EventID] = struct{}{}
+	}
 }
 
 // emitFunctionCall maps a response_item function_call onto the normalized event
@@ -650,8 +676,8 @@ func (e CodexExtractor) emitMessage(res *Result, src Source, sha string, st *cod
 // several files, each emitted as its own file.write so the patched paths are
 // first-class. Unknown tools fall back to a generic tool.call.
 func (e CodexExtractor) emitFunctionCall(res *Result, src Source, sha string, st *codexState, line int, ts string, ri *codexResponseItem) {
-	switch ri.Name {
-	case codexToolShell, codexToolShellCommand, codexToolExecCommand:
+	switch {
+	case ri.Namespace == "" && (ri.Name == codexToolShell || ri.Name == codexToolShellCommand || ri.Name == codexToolExecCommand):
 		ev := e.base(src, sha, st, line, ts, 0)
 		ev.Actor = model.ActorAssistant
 		ev.Confidence = model.ConfidenceHigh
@@ -662,9 +688,9 @@ func (e CodexExtractor) emitFunctionCall(res *Result, src Source, sha string, st
 		ev.Evidence.JSONPointer = "/payload/arguments"
 		st.noteShellCall(ri.CallID)
 		res.Events = append(res.Events, ev)
-	case codexToolApplyPatch:
+	case ri.Namespace == "" && ri.Name == codexToolApplyPatch:
 		e.emitApplyPatchCall(res, src, sha, st, line, ts, ri.Name, ri.CallID, string(ri.Arguments), "/payload/arguments")
-	case codexToolReadFile:
+	case ri.Namespace == "" && ri.Name == codexToolReadFile:
 		ev := e.base(src, sha, st, line, ts, 0)
 		ev.Actor = model.ActorAssistant
 		ev.Confidence = model.ConfidenceHigh
@@ -674,7 +700,7 @@ func (e CodexExtractor) emitFunctionCall(res *Result, src Source, sha string, st
 		ev.FilePath = codexArgString(string(ri.Arguments), "path")
 		ev.Evidence.JSONPointer = "/payload/arguments"
 		res.Events = append(res.Events, ev)
-	case codexToolWriteFile, codexToolEditFile:
+	case ri.Namespace == "" && (ri.Name == codexToolWriteFile || ri.Name == codexToolEditFile):
 		ev := e.base(src, sha, st, line, ts, 0)
 		ev.Actor = model.ActorAssistant
 		ev.Confidence = model.ConfidenceHigh
@@ -757,13 +783,8 @@ func (e CodexExtractor) emitApplyPatchCall(res *Result, src Source, sha string, 
 	}
 }
 
-// mapEventMsg decodes an event_msg payload's inner discriminator and emits only
-// the records the response_item layer does not carry: a turn that aborted
-// (interrupted/replaced/budget-limited), history that was rolled back, and the
-// review-mode / thread-goal state transitions that have no response_item twin.
-// All are low-confidence system notes tagged with the record type so the signal
-// is visible rather than a silent gap. Every other event_msg type duplicates a
-// response_item record and is skipped.
+// mapEventMsg decodes the explicit user prompt, structured MCP outcome, and
+// state transitions that are not safely recoverable from response_item alone.
 func (e CodexExtractor) mapEventMsg(res *Result, src Source, sha string, st *codexState, line int, ts string, payload json.RawMessage) {
 	var em codexEventMsg
 	if err := json.Unmarshal(payload, &em); err != nil {
@@ -771,6 +792,14 @@ func (e CodexExtractor) mapEventMsg(res *Result, src Source, sha string, st *cod
 		return
 	}
 	switch em.Type {
+	case codexEMUserMessage:
+		e.emitUserPrompt(res, src, sha, st, line, ts, em.Message, "/payload/message")
+	case codexEMItemCompleted:
+		if message, ok := decodeCodexCompletedUserMessage(em.Item); ok {
+			e.emitUserPrompt(res, src, sha, st, line, ts, message, "/payload/item/content")
+		}
+	case codexEMTaskStarted:
+		st.userPromptExpected = true
 	case codexEMTurnAborted:
 		ev := e.base(src, sha, st, line, ts, 0)
 		ev.EventType = model.EventMessageAssistant
@@ -823,8 +852,8 @@ func (e CodexExtractor) mapEventMsg(res *Result, src Source, sha string, st *cod
 			}
 		}
 	default:
-		// user_message/agent_message/patch_apply_end/... all duplicate a
-		// response_item record; skip to keep the timeline single-counted.
+		// agent_message/patch_apply_end/... duplicate response_item records; skip
+		// them to keep the timeline single-counted.
 		// Unknown/unpersisted types are skipped too.
 		//
 		// No permission.requested/approved/denied is emitted here: the rollout does
@@ -837,6 +866,64 @@ func (e CodexExtractor) mapEventMsg(res *Result, src Source, sha string, st *cod
 		// permission.* vocabulary therefore stays reserved for a future on-disk
 		// signal rather than being synthesized from a heuristic.
 	}
+}
+
+// emitUserPrompt maps the explicit user-facing lifecycle record. Codex uses
+// user_message in legacy histories and item_completed/UserMessage in paginated
+// histories; role=user response items are not sufficient proof of human input.
+func (e CodexExtractor) emitUserPrompt(res *Result, src Source, sha string, st *codexState, line int, ts, message, pointer string) {
+	st.pendingResponsePrompt = nil
+	st.userPromptExpected = false
+	if !st.explicitUserMessages {
+		st.explicitUserMessages = true
+		startID := ""
+		if st.started && st.startIdx < len(res.Events) {
+			startID = res.Events[st.startIdx].EventID
+		}
+		res.Events = discardResponsePromptEvents(res.Events, st.responsePromptIDs)
+		if startID != "" {
+			for i := range res.Events {
+				if res.Events[i].EventID == startID {
+					st.startIdx = i
+					break
+				}
+			}
+		}
+		st.responsePromptIDs = nil
+	}
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return
+	}
+	ev := e.base(src, sha, st, line, ts, 0)
+	ev.EventType = model.EventPromptUser
+	ev.Actor = model.ActorUser
+	ev.Confidence = model.ConfidenceHigh
+	ev.ContentPreview = preview(message)
+	ev.Evidence.JSONPointer = pointer
+	res.Events = append(res.Events, ev)
+}
+
+func flushCodexResponsePrompt(res *Result, st *codexState) {
+	if st.pendingResponsePrompt == nil {
+		return
+	}
+	res.Events = append(res.Events, *st.pendingResponsePrompt)
+	st.pendingResponsePrompt = nil
+}
+
+func discardResponsePromptEvents(events []model.Event, ids map[string]struct{}) []model.Event {
+	if len(ids) == 0 {
+		return events
+	}
+	out := events[:0]
+	for _, ev := range events {
+		if _, discard := ids[ev.EventID]; discard {
+			continue
+		}
+		out = append(out, ev)
+	}
+	return out
 }
 
 // markToolResultError stamps TagToolError on the already-emitted tool.result

--- a/internal/extract/codex_entry.go
+++ b/internal/extract/codex_entry.go
@@ -46,11 +46,12 @@ const (
 	codexRIContextCompaction = "context_compaction"
 )
 
-// Codex event_msg inner payload types numbat interprets. The conversation and
-// tool timeline comes from response_item; event_msg contributes only distinct
-// state changes, structured MCP failure, and the task boundary used to exclude
-// copied history from forked rollouts.
+// Codex event_msg types numbat interprets: explicit user prompts, distinct
+// state changes, structured MCP outcomes, and fork boundaries.
 const (
+	codexEMUserMessage      = "user_message"
+	codexEMItemStarted      = "item_started"
+	codexEMItemCompleted    = "item_completed"
 	codexEMTurnAborted      = "turn_aborted"
 	codexEMThreadRolledBack = "thread_rolled_back"
 	// task_started is a fork replay boundary, not an emitted timeline event.
@@ -239,14 +240,13 @@ type codexLocalShellAction struct {
 	Command []string `json:"command"`
 }
 
-// codexEventMsg is the tolerant view of an event_msg payload's inner
-// discriminator plus the fields of the few variants numbat surfaces. CallID and
-// Result are read only from an mcp_tool_call_end: they carry the structured MCP
-// outcome correlated back to the response_item layer by call_id.
+// codexEventMsg is the tolerant view of the event_msg variants numbat uses.
 type codexEventMsg struct {
-	Type   string `json:"type"`
-	TurnID string `json:"turn_id"`
-	Reason string `json:"reason"`
+	Type    string          `json:"type"`
+	TurnID  string          `json:"turn_id"`
+	Reason  string          `json:"reason"`
+	Message string          `json:"message"`
+	Item    json.RawMessage `json:"item"`
 	// CallID joins an mcp_tool_call_end to the custom_tool_call(_output) the
 	// response_item layer already emitted for the same MCP invocation.
 	CallID string `json:"call_id"`
@@ -255,6 +255,44 @@ type codexEventMsg struct {
 	// codexMcpResultIsError; left raw here so a shape numbat does not recognize is
 	// tolerated rather than failing the whole event_msg decode.
 	Result json.RawMessage `json:"result"`
+}
+
+type codexTurnItem struct {
+	Type    string             `json:"type"`
+	Content []codexContentItem `json:"content"`
+}
+
+func decodeCodexCompletedUserMessage(raw json.RawMessage) (string, bool) {
+	var item codexTurnItem
+	if json.Unmarshal(raw, &item) != nil || item.Type != "UserMessage" {
+		return "", false
+	}
+	parts := make([]string, 0, len(item.Content))
+	for _, content := range item.Content {
+		if content.Type == "text" {
+			parts = append(parts, content.Text)
+		}
+	}
+	return strings.Join(parts, ""), true
+}
+
+func codexUserPromptContinuation(line codexLine) bool {
+	if line.Type != codexTypeEventMsg {
+		return false
+	}
+	var event codexEventMsg
+	if json.Unmarshal(line.Payload, &event) != nil {
+		return true
+	}
+	switch event.Type {
+	case codexEMUserMessage:
+		return true
+	case codexEMItemStarted, codexEMItemCompleted:
+		var item codexTurnItem
+		return json.Unmarshal(event.Item, &item) == nil && item.Type == "UserMessage"
+	default:
+		return false
+	}
 }
 
 // codexMcpResultIsError reports whether an mcp_tool_call_end's result records a

--- a/internal/extract/codex_test.go
+++ b/internal/extract/codex_test.go
@@ -136,6 +136,117 @@ func TestExtractCodexMapsAllShapes(t *testing.T) {
 	assertUniqueEventIDs(t, res.Events)
 }
 
+func TestExtractCodexPrefersUserMessageEvent(t *testing.T) {
+	body := strings.Join([]string{
+		`{"timestamp":"t0","type":"session_meta","payload":{"id":"thread-1","cwd":"/repo"}}`,
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>injected</environment_context>"}]}}`,
+		`{"timestamp":"t2","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"inspect the service"}]}}`,
+		`{"timestamp":"t3","type":"event_msg","payload":{"type":"user_message","message":"inspect the service"}}`,
+		`{"timestamp":"t4","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<subagent_notification>injected</subagent_notification>"}]}}`,
+	}, "\n")
+	acts := activityEvents(extractCodex(t, body).Events)
+	if len(acts) != 1 {
+		t.Fatalf("got %d activity events, want one user prompt:\n%s", len(acts), dumpEvents(acts))
+	}
+	prompt := acts[0]
+	if prompt.EventType != model.EventPromptUser || prompt.ContentPreview != "inspect the service" {
+		t.Fatalf("prompt = %+v", prompt)
+	}
+	if prompt.Timestamp != "t3" || prompt.Evidence.Line != 4 || prompt.Evidence.JSONPointer != "/payload/message" {
+		t.Errorf("canonical prompt provenance = %q line %d %q", prompt.Timestamp, prompt.Evidence.Line, prompt.Evidence.JSONPointer)
+	}
+}
+
+func TestExtractCodexPaginatedUserMessage(t *testing.T) {
+	body := strings.Join([]string{
+		`{"timestamp":"t0","type":"session_meta","payload":{"id":"thread-1","cwd":"/repo","history_mode":"paginated"}}`,
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"paginated prompt"}]}}`,
+		`{"timestamp":"t2","type":"event_msg","payload":{"type":"item_completed","item":{"type":"UserMessage","id":"u1","content":[{"type":"text","text":"paginated"},{"type":"text","text":" "},{"type":"text","text":"prompt"}]}}}`,
+	}, "\n")
+	acts := activityEvents(extractCodex(t, body).Events)
+	if len(acts) != 1 || acts[0].EventType != model.EventPromptUser || acts[0].ContentPreview != "paginated prompt" {
+		t.Fatalf("paginated prompt =\n%s", dumpEvents(acts))
+	}
+	if acts[0].Evidence.Line != 3 || acts[0].Evidence.JSONPointer != "/payload/item/content" {
+		t.Errorf("paginated prompt provenance = line %d %q", acts[0].Evidence.Line, acts[0].Evidence.JSONPointer)
+	}
+}
+
+func TestExtractCodexNamespacedNativeNamesStayGeneric(t *testing.T) {
+	cases := []struct {
+		name   string
+		tool   string
+		call   string
+		output string
+	}{
+		{
+			name:   "exec command",
+			tool:   "exec_command",
+			call:   `{"timestamp":"t1","type":"response_item","payload":{"type":"function_call","namespace":"mcp__remote","name":"exec_command","call_id":"c","arguments":"{\"cmd\":\"id\"}"}}`,
+			output: `{"timestamp":"t2","type":"response_item","payload":{"type":"function_call_output","call_id":"c","output":"uid=1"}}`,
+		},
+		{
+			name:   "apply patch",
+			tool:   "apply_patch",
+			call:   `{"timestamp":"t1","type":"response_item","payload":{"type":"function_call","namespace":"mcp__remote","name":"apply_patch","call_id":"c","arguments":"{\"patch\":\"*** Begin Patch\\n*** Add File: x\\n+x\\n*** End Patch\"}"}}`,
+			output: `{"timestamp":"t2","type":"response_item","payload":{"type":"function_call_output","call_id":"c","output":"done"}}`,
+		},
+		{
+			name:   "read file",
+			tool:   "read_file",
+			call:   `{"timestamp":"t1","type":"response_item","payload":{"type":"function_call","namespace":"mcp__remote","name":"read_file","call_id":"c","arguments":"{\"path\":\"/etc/passwd\"}"}}`,
+			output: `{"timestamp":"t2","type":"response_item","payload":{"type":"function_call_output","call_id":"c","output":"body"}}`,
+		},
+		{
+			name:   "create file",
+			tool:   "create_file",
+			call:   `{"timestamp":"t1","type":"response_item","payload":{"type":"function_call","namespace":"mcp__remote","name":"create_file","call_id":"c","arguments":"{\"path\":\"/tmp/x\"}"}}`,
+			output: `{"timestamp":"t2","type":"response_item","payload":{"type":"function_call_output","call_id":"c","output":"done"}}`,
+		},
+		{
+			name:   "edit file",
+			tool:   "edit_file",
+			call:   `{"timestamp":"t1","type":"response_item","payload":{"type":"function_call","namespace":"mcp__remote","name":"edit_file","call_id":"c","arguments":"{\"path\":\"/tmp/x\"}"}}`,
+			output: `{"timestamp":"t2","type":"response_item","payload":{"type":"function_call_output","call_id":"c","output":"done"}}`,
+		},
+		{
+			name:   "code mode exec",
+			tool:   "exec",
+			call:   `{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","namespace":"mcp__remote","name":"exec","call_id":"c","input":"await tools.exec_command({cmd: 'id'})"}}`,
+			output: `{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"c","output":"uid=1"}}`,
+		},
+		{
+			name:   "custom apply patch",
+			tool:   "apply_patch",
+			call:   `{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","namespace":"mcp__remote","name":"apply_patch","call_id":"c","input":"*** Begin Patch\\n*** Add File: x\\n+x\\n*** End Patch"}}`,
+			output: `{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"c","output":"done"}}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := strings.Join([]string{
+				`{"timestamp":"t0","type":"session_meta","payload":{"id":"thread-1","cwd":"/repo"}}`,
+				tc.call,
+				tc.output,
+			}, "\n")
+			acts := activityEvents(extractCodex(t, body).Events)
+			if len(acts) != 2 {
+				t.Fatalf("got %d events, want call + result:\n%s", len(acts), dumpEvents(acts))
+			}
+			call, result := acts[0], acts[1]
+			if call.EventType != model.EventToolCall || call.ToolName != tc.tool || call.MCPServer != "remote" || call.MCPTool != tc.tool {
+				t.Errorf("call was specialized or lost namespace: %+v", call)
+			}
+			if call.Command != "" || call.FilePath != "" || call.DiffSHA256 != "" {
+				t.Errorf("generic MCP call carries fabricated native fields: %+v", call)
+			}
+			if result.EventType != model.EventToolResult || result.ToolCallID != "c" {
+				t.Errorf("result was promoted to a native result: %+v", result)
+			}
+		})
+	}
+}
+
 // The running project path is seeded by session_meta's cwd and updated by a
 // later turn_context; events emitted before and after the turn_context must
 // carry the corresponding directory.
@@ -168,16 +279,16 @@ func TestExtractCodexStampsProvenance(t *testing.T) {
 	if first.SessionID != "thread-1" {
 		t.Errorf("session_id = %q, want thread-1", first.SessionID)
 	}
-	if first.Timestamp != "2026-06-02T10:00:01Z" {
-		t.Errorf("timestamp = %q, want 2026-06-02T10:00:01Z", first.Timestamp)
+	if first.Timestamp != "2026-06-02T10:00:02Z" {
+		t.Errorf("timestamp = %q, want 2026-06-02T10:00:02Z", first.Timestamp)
 	}
 	ev := first.Evidence
-	// The user prompt is on line 2 of the fixture (line 1 is session_meta).
-	if ev.ArtifactType != artifactCodexRollout || ev.LocalPath != "/cases/rollout.jsonl" || ev.Line != 2 {
+	// The canonical user_message is on line 3 of the fixture.
+	if ev.ArtifactType != artifactCodexRollout || ev.LocalPath != "/cases/rollout.jsonl" || ev.Line != 3 {
 		t.Errorf("evidence = %+v", ev)
 	}
-	if ev.JSONPointer != "/payload/content" {
-		t.Errorf("json_pointer = %q, want /payload/content", ev.JSONPointer)
+	if ev.JSONPointer != "/payload/message" {
+		t.Errorf("json_pointer = %q, want /payload/message", ev.JSONPointer)
 	}
 	if len(ev.SHA256) != 64 {
 		t.Errorf("sha256 = %q, want 64 hex chars", ev.SHA256)
@@ -1142,10 +1253,78 @@ func TestExtractCodexSessionLifecycle(t *testing.T) {
 func TestExtractCodexNoSessionMetaNoLifecycle(t *testing.T) {
 	line := `{"timestamp":"t","type":"response_item","payload":{"type":"message","role":"user","content":"hi"}}`
 	res := extractCodex(t, line)
+	acts := activityEvents(res.Events)
+	if len(acts) != 1 || acts[0].EventType != model.EventPromptUser || acts[0].ContentPreview != "hi" {
+		t.Fatalf("headerless prompt fallback =\n%s", dumpEvents(acts))
+	}
 	for _, ev := range res.Events {
 		if ev.EventType == model.EventSessionStart || ev.EventType == model.EventSessionEnd {
 			t.Errorf("session lifecycle emitted without a session_meta: %+v", ev)
 		}
+	}
+}
+
+func TestExtractCodexResponsePromptFallbacks(t *testing.T) {
+	tests := []struct {
+		name        string
+		lines       []string
+		wantPrompt  string
+		wantLine    int
+		wantPointer string
+	}{
+		{
+			name: "headerless fallback replaced by explicit prompt",
+			lines: []string{
+				`{"timestamp":"t1","type":"response_item","payload":{"type":"message","role":"user","content":"human prompt"}}`,
+				`{"timestamp":"t2","type":"event_msg","payload":{"type":"user_message","message":"human prompt"}}`,
+			},
+			wantPrompt:  "human prompt",
+			wantLine:    2,
+			wantPointer: "/payload/message",
+		},
+		{
+			name: "headered prompt retained at EOF",
+			lines: []string{
+				`{"timestamp":"t0","type":"session_meta","payload":{"id":"thread-1","cwd":"/repo"}}`,
+				`{"timestamp":"t1","type":"response_item","payload":{"type":"message","role":"user","content":"truncated prompt"}}`,
+			},
+			wantPrompt:  "truncated prompt",
+			wantLine:    2,
+			wantPointer: "/payload/content",
+		},
+		{
+			name: "paginated prompt retained after item start",
+			lines: []string{
+				`{"timestamp":"t0","type":"session_meta","payload":{"id":"thread-1","cwd":"/repo"}}`,
+				`{"timestamp":"t1","type":"response_item","payload":{"type":"message","role":"user","content":"truncated prompt"}}`,
+				`{"timestamp":"t2","type":"event_msg","payload":{"type":"item_started","item":{"type":"UserMessage","content":[{"type":"text","text":"truncated prompt"}]}}}`,
+			},
+			wantPrompt:  "truncated prompt",
+			wantLine:    2,
+			wantPointer: "/payload/content",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			acts := activityEvents(extractCodex(t, strings.Join(tc.lines, "\n")).Events)
+			if len(acts) != 1 || acts[0].EventType != model.EventPromptUser || acts[0].ContentPreview != tc.wantPrompt {
+				t.Fatalf("prompt fallback =\n%s", dumpEvents(acts))
+			}
+			if acts[0].Evidence.Line != tc.wantLine || acts[0].Evidence.JSONPointer != tc.wantPointer {
+				t.Errorf("prompt provenance = line %d %q", acts[0].Evidence.Line, acts[0].Evidence.JSONPointer)
+			}
+		})
+	}
+}
+
+func TestExtractCodexDoesNotFlushInjectedContext(t *testing.T) {
+	body := strings.Join([]string{
+		`{"timestamp":"t0","type":"session_meta","payload":{"id":"thread-1","cwd":"/repo"}}`,
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"message","role":"user","content":"<environment_context>injected</environment_context>"}}`,
+		`{"timestamp":"t2","type":"world_state","payload":{"full":false}}`,
+	}, "\n")
+	if acts := activityEvents(extractCodex(t, body).Events); len(acts) != 0 {
+		t.Fatalf("injected context became a prompt:\n%s", dumpEvents(acts))
 	}
 }
 
@@ -1279,6 +1458,7 @@ func TestExtractCodexFirstSessionMetaWins(t *testing.T) {
 		`{"timestamp":"t","type":"session_meta","payload":{"id":"first","cwd":"/p"}}`,
 		`{"timestamp":"t","type":"session_meta","payload":{"id":"second","cwd":"/q"}}`,
 		`{"timestamp":"t","type":"response_item","payload":{"type":"message","role":"user","content":"hi"}}`,
+		`{"timestamp":"t","type":"event_msg","payload":{"type":"user_message","message":"hi"}}`,
 	}, "\n")
 	acts := activityEvents(extractCodex(t, body).Events)
 	if len(acts) != 1 {
@@ -1303,8 +1483,9 @@ func TestExtractCodexForkSkipsCopiedHistory(t *testing.T) {
 		`{"timestamp":"t9","type":"event_msg","payload":{"type":"task_started","turn_id":"019f84ff-90e1-7f12-9b81-ed81048178c1"}}`,
 		`{"timestamp":"t10","type":"turn_context","payload":{"cwd":"/child/live"}}`,
 		`{"timestamp":"t11","type":"response_item","payload":{"type":"message","role":"user","content":"child prompt"}}`,
-		`{"timestamp":"t12","type":"response_item","payload":{"type":"function_call","name":"shell","call_id":"child","arguments":"{\"command\":\"echo child\"}"}}`,
-		`{"timestamp":"t13","type":"response_item","payload":{"type":"function_call_output","call_id":"child","output":"done"}}`,
+		`{"timestamp":"t12","type":"event_msg","payload":{"type":"user_message","message":"child prompt"}}`,
+		`{"timestamp":"t13","type":"response_item","payload":{"type":"function_call","name":"shell","call_id":"child","arguments":"{\"command\":\"echo child\"}"}}`,
+		`{"timestamp":"t14","type":"response_item","payload":{"type":"function_call_output","call_id":"child","output":"done"}}`,
 	}, "\n")
 	res := extractCodex(t, body)
 	acts := activityEvents(res.Events)
@@ -1321,8 +1502,8 @@ func TestExtractCodexForkSkipsCopiedHistory(t *testing.T) {
 			t.Errorf("child event identity = session %q path %q", ev.SessionID, ev.ProjectPath)
 		}
 	}
-	if acts[0].Evidence.Line != 11 {
-		t.Errorf("first child event line = %d, want 11", acts[0].Evidence.Line)
+	if acts[0].Evidence.Line != 12 {
+		t.Errorf("first child event line = %d, want 12", acts[0].Evidence.Line)
 	}
 	if len(res.Diagnostics) != 1 || !strings.Contains(res.Diagnostics[0].Msg, "may be omitted") {
 		t.Errorf("diagnostics = %+v, want one bounded uncertainty warning", res.Diagnostics)
@@ -1357,6 +1538,7 @@ func TestExtractCodexForkIgnoresCopiedLegacyTaskID(t *testing.T) {
 		`{"timestamp":"t4","type":"response_item","payload":{"type":"message","role":"user","content":"copied"}}`,
 		`{"timestamp":"t5","type":"event_msg","payload":{"type":"task_started","turn_id":"019f84ff-90e1-7f12-9b81-ed81048178c1"}}`,
 		`{"timestamp":"t6","type":"response_item","payload":{"type":"message","role":"user","content":"child"}}`,
+		`{"timestamp":"t7","type":"event_msg","payload":{"type":"user_message","message":"child"}}`,
 	}, "\n")
 	res := extractCodex(t, body)
 	acts := activityEvents(res.Events)
@@ -1372,6 +1554,7 @@ func TestExtractCodexForkWithLegacyIDFailsOpen(t *testing.T) {
 	body := strings.Join([]string{
 		`{"timestamp":"t1","type":"session_meta","payload":{"id":"legacy-child","forked_from_id":"legacy-parent","cwd":"/child"}}`,
 		`{"timestamp":"t2","type":"response_item","payload":{"type":"message","role":"user","content":"visible"}}`,
+		`{"timestamp":"t3","type":"event_msg","payload":{"type":"user_message","message":"visible"}}`,
 	}, "\n")
 	res := extractCodex(t, body)
 	acts := activityEvents(res.Events)
@@ -1401,6 +1584,7 @@ func TestExtractCodexForkUnreadableBoundaryWarns(t *testing.T) {
 				tc.row,
 				boundary,
 				`{"timestamp":"t4","type":"response_item","payload":{"type":"message","role":"user","content":"child"}}`,
+				`{"timestamp":"t5","type":"event_msg","payload":{"type":"user_message","message":"child"}}`,
 			}, "\n")
 			res, err := CodexExtractor{maxBytes: len(body) + 1}.Extract(strings.NewReader(body), Source{Path: "/cases/fork.jsonl"})
 			if err != nil {

--- a/internal/extract/openclaw.go
+++ b/internal/extract/openclaw.go
@@ -59,9 +59,14 @@ type openClawState struct {
 	// emitted. The later output consults this so it still carries the tool-error
 	// signal regardless of the order the two layers land in the transcript —
 	// mirroring codexState.failedMCPCallIDs.
-	failedMCPCallIDs map[string]struct{}
-	toolEvents       int
-	recognizedRows   int
+	failedMCPCallIDs           map[string]struct{}
+	codexMetaSeen              bool
+	codexExplicitUserMessages  bool
+	codexUserPromptExpected    bool
+	codexResponsePromptIDs     map[string]struct{}
+	pendingCodexResponsePrompt *model.Event
+	toolEvents                 int
+	recognizedRows             int
 }
 
 // noteCommandCall records a tool-call id that was a command (shell/exec) so its
@@ -167,6 +172,9 @@ func (e OpenClawExtractor) Extract(r io.Reader, src Source) (*Result, error) {
 		}
 	}
 
+	if flavor == openClawFlavorCodex {
+		flushOpenClawCodexResponsePrompt(res, st)
+	}
 	e.surfaceCoverageGap(res, src, flavor, nonBlank, skippedLong, st)
 	return res, nil
 }

--- a/internal/extract/openclaw_codex.go
+++ b/internal/extract/openclaw_codex.go
@@ -14,30 +14,20 @@ import (
 // decodes that format with full fidelity, reusing the Codex wire helpers
 // (codex_entry.go) so the two extractors stay in lockstep on the on-disk shape.
 //
-// Only the structurally-confirmed forensic signals are surfaced: function_call
-// (shell→command.exec, apply_patch→file.write/delete, read/write/edit file,
-// canonical MCP fetch→network.indicator, else tool.call), function_call_output
-// (correlated by call_id to a command.result or tool.result), local_shell_call,
-// and web_search_call. From the event_msg layer, only the records with no
-// response_item twin are surfaced: a structured mcp_tool_call_end failure tags
-// the matching tool.result TagToolError, and the no-twin state transitions
-// (turn_aborted / thread_rolled_back / review-mode / thread-goal) become
-// low-confidence system notes (see mapCodexEventMsg). Per the high-precision
-// boundary, legacy shell output never has its prose scraped for an exit code,
-// and a tool-error tag is set only from a structured field.
+// The mapping follows the native Codex extractor: explicit lifecycle records
+// identify human prompts, response_item carries assistant/tool activity, and
+// structured event_msg outcomes enrich correlated results.
 
-// mapCodexLine decodes one Codex-flavor OpenClaw line and dispatches on the
-// outer record type. A malformed line is a diagnostic and is skipped; the rest of
-// the file still parses. session_meta / turn_context seed and update the session
-// working directory; response_item carries the tool/message timeline; event_msg
-// is routed to mapCodexEventMsg, which surfaces only the no-response_item-twin
-// signals (structured MCP tool-error, no-twin state transitions) and skips the
-// duplicate types — mirroring the canonical Codex extractor (codex.go mapEventMsg).
+// mapCodexLine dispatches an embedded Codex rollout row while retaining
+// OpenClaw's identity and event IDs.
 func (e OpenClawExtractor) mapCodexLine(res *Result, src Source, sha string, st *openClawState, line int, raw []byte) {
 	var lineRec codexLine
 	if err := json.Unmarshal(raw, &lineRec); err != nil {
 		res.diag(src.Path, line, "malformed JSON line")
 		return
+	}
+	if st.pendingCodexResponsePrompt != nil && !codexUserPromptContinuation(lineRec) {
+		st.pendingCodexResponsePrompt = nil
 	}
 	// Codex rollout rows carry their timestamp on the outer envelope. Reset it
 	// for every row so a legacy/malformed row cannot inherit its predecessor.
@@ -45,6 +35,7 @@ func (e OpenClawExtractor) mapCodexLine(res *Result, src Source, sha string, st 
 	switch lineRec.Type {
 	case openClawTypeSessionMeta:
 		st.recognizedRows++
+		st.codexMetaSeen = true
 		var meta codexSessionMeta
 		if json.Unmarshal(lineRec.Payload, &meta) == nil {
 			if st.sessionID == "" {
@@ -188,7 +179,7 @@ func (e OpenClawExtractor) mapCodexResponseItem(res *Result, src Source, sha str
 	case codexRICustomToolCall:
 		// A new call owns a reused id and its next output.
 		st.resetCall(ri.CallID)
-		if ri.Name == codexToolCodeModeExec {
+		if ri.Namespace == "" && ri.Name == codexToolCodeModeExec {
 			if call, ok := parseCodexCodeModeExec(string(ri.Input)); ok {
 				ev := e.base(src, sha, st, line, 0)
 				ev.Actor = model.ActorAssistant
@@ -269,23 +260,8 @@ func (e OpenClawExtractor) mapCodexResponseItem(res *Result, src Source, sha str
 	}
 }
 
-// mapCodexEventMsg decodes a Codex-flavor event_msg payload and surfaces only the
-// records the response_item layer does not carry, reusing the same wire types and
-// helpers as the canonical extractor (codexEventMsg / codexMcpResultIsError /
-// markToolResultError) routed through OpenClaw's event base/id/state. It is the
-// OpenClaw mirror of codex.go mapEventMsg:
-//   - mcp_tool_call_end: read ONLY the structured Result; on a recorded failure tag
-//     the already-emitted tool.result for the call_id TagToolError, or — when the
-//     end-event preceded the output — note the failed call_id so the later output is
-//     tagged. Success / unrecognized shape leaves the tool.result untagged (never
-//     scrape prose).
-//   - turn_aborted / thread_rolled_back / entered_review_mode / exited_review_mode /
-//     thread_goal_updated: low-confidence message.assistant system notes tagged with
-//     the transition type, JSONPointer /payload (the OpenClaw outer row is
-//     {timestamp,type,payload}, so /payload resolves).
-//   - every other type duplicates a response_item record and is skipped.
-//
-// A malformed payload is a diagnostic and skipped (no panic).
+// mapCodexEventMsg mirrors codex.go for explicit prompts, state transitions,
+// and structured MCP failures. Duplicate lifecycle records are skipped.
 func (e OpenClawExtractor) mapCodexEventMsg(res *Result, src Source, sha string, st *openClawState, line int, payload json.RawMessage) {
 	var em codexEventMsg
 	if err := json.Unmarshal(payload, &em); err != nil {
@@ -293,6 +269,14 @@ func (e OpenClawExtractor) mapCodexEventMsg(res *Result, src Source, sha string,
 		return
 	}
 	switch em.Type {
+	case codexEMUserMessage:
+		e.emitCodexUserPrompt(res, src, sha, st, line, em.Message, "/payload/message")
+	case codexEMItemCompleted:
+		if message, ok := decodeCodexCompletedUserMessage(em.Item); ok {
+			e.emitCodexUserPrompt(res, src, sha, st, line, message, "/payload/item/content")
+		}
+	case codexEMTaskStarted:
+		st.codexUserPromptExpected = true
 	case codexEMTurnAborted:
 		ev := e.base(src, sha, st, line, 0)
 		ev.EventType = model.EventMessageAssistant
@@ -329,17 +313,13 @@ func (e OpenClawExtractor) mapCodexEventMsg(res *Result, src Source, sha string,
 			}
 		}
 	default:
-		// user_message / agent_message / patch_apply_end / ... duplicate a
-		// response_item record; unknown/unpersisted types are skipped too. Same
-		// single-counted-timeline posture as codex.go (no permission.* synthesized).
+		// agent_message / patch_apply_end / ... duplicate response_item records;
+		// unknown and unpersisted types are skipped too.
 	}
 }
 
-// emitCodexMessage emits a prompt.user or message.assistant from a Codex
-// response_item message. role determines the actor; developer/system messages are
-// instructions, not agent activity, and are skipped. An empty body yields
-// nothing. Prose is a message event (not a tool event), so it does not advance
-// the tool-activity counter.
+// emitCodexMessage emits assistant prose and the compatibility prompt fallback
+// used only when no explicit user-message lifecycle record appears.
 func (e OpenClawExtractor) emitCodexMessage(res *Result, src Source, sha string, st *openClawState, line int, ri *codexResponseItem) {
 	text := strings.TrimSpace(decodeCodexContentText(ri.Content))
 	if text == "" {
@@ -351,6 +331,17 @@ func (e OpenClawExtractor) emitCodexMessage(res *Result, src Source, sha string,
 	ev.Evidence.JSONPointer = "/payload/content"
 	switch ri.Role {
 	case "user":
+		if st.codexMetaSeen || st.codexExplicitUserMessages {
+			if !st.codexExplicitUserMessages || st.codexUserPromptExpected {
+				ev.EventType = model.EventPromptUser
+				ev.Actor = model.ActorUser
+				ev.Confidence = model.ConfidenceMedium
+				ev.SessionID = st.sessionID
+				ev.ProjectPath = st.projectPath
+				st.pendingCodexResponsePrompt = &ev
+			}
+			return
+		}
 		ev.EventType = model.EventPromptUser
 		ev.Actor = model.ActorUser
 	case "assistant":
@@ -361,6 +352,41 @@ func (e OpenClawExtractor) emitCodexMessage(res *Result, src Source, sha string,
 		return
 	}
 	res.appendEvent(st, ev, false)
+	if ri.Role == "user" {
+		if st.codexResponsePromptIDs == nil {
+			st.codexResponsePromptIDs = map[string]struct{}{}
+		}
+		st.codexResponsePromptIDs[ev.EventID] = struct{}{}
+	}
+}
+
+func (e OpenClawExtractor) emitCodexUserPrompt(res *Result, src Source, sha string, st *openClawState, line int, message, pointer string) {
+	st.pendingCodexResponsePrompt = nil
+	st.codexUserPromptExpected = false
+	if !st.codexExplicitUserMessages {
+		st.codexExplicitUserMessages = true
+		res.Events = discardResponsePromptEvents(res.Events, st.codexResponsePromptIDs)
+		st.codexResponsePromptIDs = nil
+	}
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return
+	}
+	ev := e.base(src, sha, st, line, 0)
+	ev.EventType = model.EventPromptUser
+	ev.Actor = model.ActorUser
+	ev.Confidence = model.ConfidenceHigh
+	ev.ContentPreview = preview(message)
+	ev.Evidence.JSONPointer = pointer
+	res.appendEvent(st, ev, false)
+}
+
+func flushOpenClawCodexResponsePrompt(res *Result, st *openClawState) {
+	if st.pendingCodexResponsePrompt == nil {
+		return
+	}
+	res.Events = append(res.Events, *st.pendingCodexResponsePrompt)
+	st.pendingCodexResponsePrompt = nil
 }
 
 // emitCodexFunctionCall maps a Codex response_item function_call onto the
@@ -371,8 +397,8 @@ func (e OpenClawExtractor) emitCodexMessage(res *Result, src Source, sha string,
 // fetch→network.indicator, and every other tool→a generic tool.call. Mirrors
 // codex.go emitFunctionCall but routes through OpenClaw's id/state/counter.
 func (e OpenClawExtractor) emitCodexFunctionCall(res *Result, src Source, sha string, st *openClawState, line int, ri *codexResponseItem) {
-	switch ri.Name {
-	case codexToolShell, codexToolShellCommand, codexToolExecCommand:
+	switch {
+	case ri.Namespace == "" && (ri.Name == codexToolShell || ri.Name == codexToolShellCommand || ri.Name == codexToolExecCommand):
 		ev := e.base(src, sha, st, line, 0)
 		ev.Actor = model.ActorAssistant
 		ev.Confidence = model.ConfidenceHigh
@@ -383,7 +409,7 @@ func (e OpenClawExtractor) emitCodexFunctionCall(res *Result, src Source, sha st
 		ev.Evidence.JSONPointer = "/payload/arguments"
 		st.noteCommandCall(ri.CallID)
 		res.appendEvent(st, ev, true)
-	case codexToolApplyPatch:
+	case ri.Namespace == "" && ri.Name == codexToolApplyPatch:
 		// apply_patch is a REQUEST to change files, not a confirmed write: the
 		// function_call records intent. numbat emits the requested changes at
 		// medium confidence with an intent tag, the same single-layer posture
@@ -422,7 +448,7 @@ func (e OpenClawExtractor) emitCodexFunctionCall(res *Result, src Source, sha st
 			ev.Evidence.JSONPointer = "/payload/arguments"
 			res.appendEvent(st, ev, true)
 		}
-	case codexToolReadFile:
+	case ri.Namespace == "" && ri.Name == codexToolReadFile:
 		ev := e.base(src, sha, st, line, 0)
 		ev.Actor = model.ActorAssistant
 		ev.Confidence = model.ConfidenceHigh
@@ -432,7 +458,7 @@ func (e OpenClawExtractor) emitCodexFunctionCall(res *Result, src Source, sha st
 		ev.FilePath = codexArgString(string(ri.Arguments), "path")
 		ev.Evidence.JSONPointer = "/payload/arguments"
 		res.appendEvent(st, ev, true)
-	case codexToolWriteFile, codexToolEditFile:
+	case ri.Namespace == "" && (ri.Name == codexToolWriteFile || ri.Name == codexToolEditFile):
 		ev := e.base(src, sha, st, line, 0)
 		ev.Actor = model.ActorAssistant
 		ev.Confidence = model.ConfidenceHigh

--- a/internal/extract/openclaw_test.go
+++ b/internal/extract/openclaw_test.go
@@ -1725,4 +1725,176 @@ func TestOpenClawCodexOuterTimestamp(t *testing.T) {
 	}
 }
 
+func TestOpenClawCodexPrefersUserMessageEvent(t *testing.T) {
+	lines := []string{
+		`{"timestamp":"t0","type":"session_meta","payload":{"id":"cx","cwd":"/w"}}`,
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>injected</environment_context>"}]}}`,
+		`{"timestamp":"t2","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"human prompt"}]}}`,
+		`{"timestamp":"t3","type":"event_msg","payload":{"type":"user_message","message":"human prompt"}}`,
+	}
+	res := extractOpenClaw(t, strings.Join(lines, "\n"))
+	if len(res.Events) != 1 || res.Events[0].EventType != model.EventPromptUser || res.Events[0].ContentPreview != "human prompt" {
+		t.Fatalf("canonical prompt mapping = %+v", res.Events)
+	}
+	if res.Events[0].Evidence.Line != 4 || res.Events[0].Evidence.JSONPointer != "/payload/message" {
+		t.Errorf("canonical prompt provenance = line %d %q", res.Events[0].Evidence.Line, res.Events[0].Evidence.JSONPointer)
+	}
+	assertOpenClawPointersResolve(t, res, lines)
+}
+
+func TestOpenClawCodexPaginatedUserMessage(t *testing.T) {
+	lines := []string{
+		`{"timestamp":"t0","type":"session_meta","payload":{"id":"cx","cwd":"/w","history_mode":"paginated"}}`,
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"paginated prompt"}]}}`,
+		`{"timestamp":"t2","type":"event_msg","payload":{"type":"item_completed","item":{"type":"UserMessage","id":"u1","content":[{"type":"text","text":"paginated"},{"type":"text","text":" "},{"type":"text","text":"prompt"}]}}}`,
+	}
+	res := extractOpenClaw(t, strings.Join(lines, "\n"))
+	if len(res.Events) != 1 || res.Events[0].EventType != model.EventPromptUser || res.Events[0].ContentPreview != "paginated prompt" {
+		t.Fatalf("paginated prompt mapping = %+v", res.Events)
+	}
+	if res.Events[0].Evidence.Line != 3 || res.Events[0].Evidence.JSONPointer != "/payload/item/content" {
+		t.Errorf("paginated prompt provenance = line %d %q", res.Events[0].Evidence.Line, res.Events[0].Evidence.JSONPointer)
+	}
+	assertOpenClawPointersResolve(t, res, lines)
+}
+
+func TestOpenClawCodexResponsePromptFallbacks(t *testing.T) {
+	tests := []struct {
+		name        string
+		lines       []string
+		wantLine    int
+		wantPointer string
+	}{
+		{
+			name: "headerless response only",
+			lines: []string{
+				`{"timestamp":"t1","type":"response_item","payload":{"type":"message","role":"user","content":"human prompt"}}`,
+			},
+			wantLine:    1,
+			wantPointer: "/payload/content",
+		},
+		{
+			name: "headerless response replaced by explicit prompt",
+			lines: []string{
+				`{"timestamp":"t1","type":"response_item","payload":{"type":"message","role":"user","content":"human prompt"}}`,
+				`{"timestamp":"t2","type":"event_msg","payload":{"type":"user_message","message":"human prompt"}}`,
+			},
+			wantLine:    2,
+			wantPointer: "/payload/message",
+		},
+		{
+			name: "headered response retained at EOF",
+			lines: []string{
+				`{"timestamp":"t0","type":"session_meta","payload":{"id":"cx","cwd":"/w"}}`,
+				`{"timestamp":"t1","type":"response_item","payload":{"type":"message","role":"user","content":"human prompt"}}`,
+			},
+			wantLine:    2,
+			wantPointer: "/payload/content",
+		},
+		{
+			name: "paginated response retained after item start",
+			lines: []string{
+				`{"timestamp":"t0","type":"session_meta","payload":{"id":"cx","cwd":"/w"}}`,
+				`{"timestamp":"t1","type":"response_item","payload":{"type":"message","role":"user","content":"human prompt"}}`,
+				`{"timestamp":"t2","type":"event_msg","payload":{"type":"item_started","item":{"type":"UserMessage","content":[{"type":"text","text":"human prompt"}]}}}`,
+			},
+			wantLine:    2,
+			wantPointer: "/payload/content",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res := extractOpenClaw(t, strings.Join(tc.lines, "\n"))
+			if len(res.Events) != 1 || res.Events[0].EventType != model.EventPromptUser || res.Events[0].ContentPreview != "human prompt" {
+				t.Fatalf("prompt fallback = %+v", res.Events)
+			}
+			if res.Events[0].Evidence.Line != tc.wantLine || res.Events[0].Evidence.JSONPointer != tc.wantPointer {
+				t.Errorf("prompt provenance = line %d %q", res.Events[0].Evidence.Line, res.Events[0].Evidence.JSONPointer)
+			}
+			assertOpenClawPointersResolve(t, res, tc.lines)
+		})
+	}
+}
+
+func TestOpenClawCodexDoesNotFlushInjectedContext(t *testing.T) {
+	lines := []string{
+		`{"timestamp":"t0","type":"session_meta","payload":{"id":"cx","cwd":"/w"}}`,
+		`{"timestamp":"t1","type":"response_item","payload":{"type":"message","role":"user","content":"<environment_context>injected</environment_context>"}}`,
+		`{"timestamp":"t2","type":"world_state","payload":{"full":false}}`,
+	}
+	if res := extractOpenClaw(t, strings.Join(lines, "\n")); len(res.Events) != 0 {
+		t.Fatalf("injected context became a prompt: %+v", res.Events)
+	}
+}
+
+func TestOpenClawCodexNamespacedNativeNamesStayGeneric(t *testing.T) {
+	cases := []struct {
+		name   string
+		tool   string
+		call   string
+		output string
+	}{
+		{
+			name:   "exec command",
+			tool:   "exec_command",
+			call:   `{"timestamp":"t1","type":"response_item","payload":{"type":"function_call","namespace":"mcp__remote","name":"exec_command","call_id":"c","arguments":"{\"cmd\":\"id\"}"}}`,
+			output: `{"timestamp":"t2","type":"response_item","payload":{"type":"function_call_output","call_id":"c","output":"uid=1"}}`,
+		},
+		{
+			name:   "apply patch",
+			tool:   "apply_patch",
+			call:   `{"timestamp":"t1","type":"response_item","payload":{"type":"function_call","namespace":"mcp__remote","name":"apply_patch","call_id":"c","arguments":"{\"patch\":\"*** Begin Patch\\n*** Add File: x\\n+x\\n*** End Patch\"}"}}`,
+			output: `{"timestamp":"t2","type":"response_item","payload":{"type":"function_call_output","call_id":"c","output":"done"}}`,
+		},
+		{
+			name:   "read file",
+			tool:   "read_file",
+			call:   `{"timestamp":"t1","type":"response_item","payload":{"type":"function_call","namespace":"mcp__remote","name":"read_file","call_id":"c","arguments":"{\"path\":\"/etc/passwd\"}"}}`,
+			output: `{"timestamp":"t2","type":"response_item","payload":{"type":"function_call_output","call_id":"c","output":"body"}}`,
+		},
+		{
+			name:   "create file",
+			tool:   "create_file",
+			call:   `{"timestamp":"t1","type":"response_item","payload":{"type":"function_call","namespace":"mcp__remote","name":"create_file","call_id":"c","arguments":"{\"path\":\"/tmp/x\"}"}}`,
+			output: `{"timestamp":"t2","type":"response_item","payload":{"type":"function_call_output","call_id":"c","output":"done"}}`,
+		},
+		{
+			name:   "edit file",
+			tool:   "edit_file",
+			call:   `{"timestamp":"t1","type":"response_item","payload":{"type":"function_call","namespace":"mcp__remote","name":"edit_file","call_id":"c","arguments":"{\"path\":\"/tmp/x\"}"}}`,
+			output: `{"timestamp":"t2","type":"response_item","payload":{"type":"function_call_output","call_id":"c","output":"done"}}`,
+		},
+		{
+			name:   "code mode exec",
+			tool:   "exec",
+			call:   `{"timestamp":"t1","type":"response_item","payload":{"type":"custom_tool_call","namespace":"mcp__remote","name":"exec","call_id":"c","input":"await tools.exec_command({cmd: 'id'})"}}`,
+			output: `{"timestamp":"t2","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"c","output":"uid=1"}}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lines := []string{
+				`{"timestamp":"t0","type":"session_meta","payload":{"id":"cx","cwd":"/w"}}`,
+				tc.call,
+				tc.output,
+			}
+			res := extractOpenClaw(t, strings.Join(lines, "\n"))
+			if len(res.Events) != 2 {
+				t.Fatalf("got %d events, want call + result: %+v", len(res.Events), res.Events)
+			}
+			call, result := res.Events[0], res.Events[1]
+			if call.EventType != model.EventToolCall || call.ToolName != tc.tool || call.MCPServer != "remote" || call.MCPTool != tc.tool {
+				t.Errorf("call was specialized or lost namespace: %+v", call)
+			}
+			if call.Command != "" || call.FilePath != "" || call.DiffSHA256 != "" {
+				t.Errorf("generic MCP call carries fabricated native fields: %+v", call)
+			}
+			if result.EventType != model.EventToolResult || result.ToolCallID != "c" {
+				t.Errorf("result was promoted to a native result: %+v", result)
+			}
+			assertOpenClawPointersResolve(t, res, lines)
+		})
+	}
+}
+
 func intPtr(v int) *int { return &v }


### PR DESCRIPTION
## Summary
- retain prompt attribution across Codex rollout records
- preserve original tool provenance for normalized code-mode commands
- improve correlation across direct and OpenClaw-wrapped traces

Stacked on #10.

## Validation
- `go test ./internal/extract ./internal/rule`