### PR TITLE
Fix OTLP file-event normalization

### DIFF
--- a/cmd/numbat/collect.go
+++ b/cmd/numbat/collect.go
@@ -365,6 +365,9 @@ func (c *collector) handleLogs(w http.ResponseWriter, r *http.Request) {
 	rejected := int64(0)
 	noAnalog := 0
 	for _, res := range results {
+		if res.Ignored {
+			continue
+		}
 		if !res.Mapped {
 			c.skippedN.Add(1)
 			rejected++

--- a/cmd/numbat/collect_test.go
+++ b/cmd/numbat/collect_test.go
@@ -297,6 +297,55 @@ func TestCollectHandlerSkipsNoAnalog(t *testing.T) {
 	}
 }
 
+func TestCollectHandlerSilentlyIgnoresSupplementalFileOperation(t *testing.T) {
+	var records, diags bytes.Buffer
+	c := newTestCollector(t, &records, &diags, emitSelection{events: true})
+
+	body := buildOTLPLogs("gemini-cli", []map[string]string{
+		{
+			"__event_name":  "gemini_cli.tool_call",
+			"function_name": "write_file",
+			"function_args": `{"file_path":"/tmp/agent.txt"}`,
+			"success":       "true",
+		},
+		{
+			"__event_name": "gemini_cli.file_operation",
+			"tool_name":    "write_file",
+			"operation":    "create",
+		},
+	})
+	rr := postLogs(t, c, body, contentTypeProtobuf)
+	if rr.Code != http.StatusOK || rr.Body.Len() != 0 {
+		t.Fatalf("response = %d %x, want empty 200", rr.Code, rr.Body.Bytes())
+	}
+	if diags.Len() != 0 {
+		t.Fatalf("unexpected diagnostics: %s", diags.String())
+	}
+	if c.processed() != 1 || c.skipped() != 0 {
+		t.Fatalf("processed/skipped = %d/%d, want 1/0", c.processed(), c.skipped())
+	}
+
+	var events int
+	for _, line := range strings.Split(strings.TrimSpace(records.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("bad record JSON: %v", err)
+		}
+		if rec["record_type"] == output.RecordEvent {
+			events++
+			if rec["event_type"] != "file.write" || rec["file_path"] != "/tmp/agent.txt" {
+				t.Fatalf("normalized event = %v", rec)
+			}
+		}
+	}
+	if events != 1 {
+		t.Fatalf("events = %d, want 1", events)
+	}
+}
+
 type failedCollectWriter struct{}
 
 func (failedCollectWriter) Write([]byte) (int, error) { return 0, io.ErrClosedPipe }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -390,6 +390,8 @@ explicitly:
 - **Gemini CLI** — defaults to gRPC on `:4317`, which numbat does not serve. Set
   `otlpProtocol=http` (in `~/.gemini/settings.json` telemetry settings or via the
   CLI flags) and point the OTLP endpoint at numbat's `http://127.0.0.1:4318`.
+  Command, file, and network targets require `logPrompts=true`, which also
+  exports prompts, tool inputs, and model responses.
 - **Qwen Code** — enable telemetry, set `otlpProtocol` to `http`, and set
   `otlpLogsEndpoint` (or `QWEN_TELEMETRY_OTLP_LOGS_ENDPOINT`) to
   `http://127.0.0.1:4318/v1/logs`. Keep `logPrompts` disabled when prompt content

--- a/internal/otel/alias.go
+++ b/internal/otel/alias.go
@@ -100,11 +100,6 @@ const (
 	attrStatus       = "status"
 	attrToolCallID   = "tool.call_id"
 
-	// attrOperation is Gemini's file_operation direction key (read/create/update);
-	// it is NOT the standard file.operation key, so the Gemini path resolves it
-	// explicitly rather than relying on classifyFile's tool-name fallback.
-	attrOperation = "operation"
-
 	// attrOutput is the Codex tool_result output snippet.
 	attrOutput    = "output"
 	attrArguments = "arguments"
@@ -119,9 +114,6 @@ const (
 	// object (matching internal/extract/gemini's run_shell_command / file tools).
 	argCommand  = "command"
 	argFilePath = "file_path"
-
-	attrPathAlt     = "path"
-	attrFilePathAlt = "file_path"
 )
 
 // classifyAgentAlias maps a Claude, Codex, Gemini, or OpenCode private record onto
@@ -218,9 +210,6 @@ func classifyAgentAlias(ev *model.Event, a *attrs, rec logRecord, name string) b
 	case geminiToolCall, qwenToolCall:
 		classifyGeminiToolCall(ev, a, rec)
 		return true
-
-	case geminiFileOperation, qwenFileOperation:
-		return classifyGeminiFileOperation(ev, a, rec)
 
 	case geminiAPIResponse, qwenAPIResponse:
 		ev.EventType = model.EventMessageAssistant
@@ -607,34 +596,6 @@ func classifyGeminiToolCall(ev *model.Event, a *attrs, rec logRecord) {
 	}
 }
 
-// classifyGeminiFileOperation maps gemini_cli.file_operation onto file.read or
-// file.write. The direction comes from Gemini's bare "operation" attribute
-// (read -> file.read; create/update -> file.write), which is NOT the standard
-// file.operation key classifyFile reads — so it is resolved here explicitly
-// rather than left to classifyFile's tool-name heuristic, which would
-// misclassify a write whose tool_name carries no write/edit/create token. The
-// file path is read from the standard/Gemini keys, falling back to function_args.
-func classifyGeminiFileOperation(ev *model.Event, a *attrs, rec logRecord) bool {
-	ev.ToolName = a.str(attrAliasToolName, attrGenAIToolName, attrToolName)
-	ev.FilePath = firstNonEmpty(
-		a.str(attrFilePath, attrFilePathAlt, attrPathAlt, attrCodePath),
-		geminiArgField(a, argFilePath),
-	)
-
-	switch strings.ToLower(strings.TrimSpace(a.str(attrOperation))) {
-	case "create", "update":
-		ev.EventType = model.EventFileWrite
-	case "read":
-		ev.EventType = model.EventFileRead
-	default:
-		return false
-	}
-	if errored(a, rec) {
-		ev.Tags = append(ev.Tags, model.TagToolError)
-	}
-	return true
-}
-
 func classifyGeminiPermissionMode(ev *model.Event, a *attrs) {
 	mode := a.str(attrClaudeToMode)
 	ev.EventType = model.EventConfigAgent
@@ -648,31 +609,6 @@ func classifyGeminiPermissionMode(ev *model.Event, a *attrs) {
 func geminiModeElevated(mode string) bool {
 	normalized := strings.NewReplacer("_", "", "-", "").Replace(strings.ToLower(strings.TrimSpace(mode)))
 	return normalized == "yolo" || normalized == "autoedit"
-}
-
-// geminiArgField pulls a top-level string field out of Gemini's function_args
-// attribute, which arrives as a JSON object encoded in a string AnyValue. It
-// returns "" when function_args is absent, not an object, or lacks a string at
-// key. This mirrors internal/extract/gemini's geminiArgString over the on-disk
-// args map; here the map is one JSON hop away inside an OTLP attribute.
-func geminiArgField(a *attrs, key string) string {
-	raw := a.str(attrFunctionArgs)
-	if raw == "" {
-		return ""
-	}
-	var m map[string]json.RawMessage
-	if json.Unmarshal([]byte(raw), &m) != nil {
-		return ""
-	}
-	v, ok := m[key]
-	if !ok {
-		return ""
-	}
-	var s string
-	if json.Unmarshal(v, &s) != nil {
-		return ""
-	}
-	return s
 }
 
 // isShellToolName reports whether a tool name denotes shell/command execution,

--- a/internal/otel/alias_test.go
+++ b/internal/otel/alias_test.go
@@ -394,6 +394,19 @@ func TestGeminiAliases(t *testing.T) {
 		mustValidate(t, ev)
 	})
 
+	t.Run("tool_call_file_write_without_logged_args", func(t *testing.T) {
+		rec := recBuilder{attrs: [][]byte{
+			eventNameAttr(geminiToolCall),
+			kv(attrFunctionName, "write_file"),
+			kvAny(attrSuccess, anyBool(true)),
+		}}.build()
+		ev := mustMap(t, resource, rec)
+		if ev.EventType != model.EventFileWrite || ev.FilePath != "" {
+			t.Fatalf("file tool without arguments = %+v", ev)
+		}
+		mustValidate(t, ev)
+	})
+
 	t.Run("api response", func(t *testing.T) {
 		rec := recBuilder{attrs: [][]byte{
 			eventNameAttr(geminiAPIResponse),
@@ -451,74 +464,66 @@ func TestGeminiAliases(t *testing.T) {
 		}
 	})
 
-	t.Run("file_operation_read", func(t *testing.T) {
-		// A NEUTRAL tool_name (no read/view token) so the direction can only come
-		// from the bare "operation" attribute, not classifyFile's name heuristic.
+	t.Run("file_operation_skips", func(t *testing.T) {
 		rec := recBuilder{attrs: [][]byte{
 			eventNameAttr(geminiFileOperation),
-			kv(attrAliasToolName, "fs_tool"),
-			kv(attrOperation, "read"),
-			kv(attrFilePathAlt, "/etc/shadow"),
+			kv(attrAliasToolName, "write_file"),
+			kv("operation", "create"),
+			kv(attrGenAIToolName, "write_file"),
+			kv(attrFilePath, "/tmp/coincidental.txt"),
 		}}.build()
-		ev := mustMap(t, resource, rec)
-		if ev.EventType != model.EventFileRead {
-			t.Errorf("event_type = %q, want file.read from operation alone", ev.EventType)
+		if res := mapOne(t, resource, rec); res.Mapped || !res.Ignored {
+			t.Fatalf("supplemental file operation result = %+v", res)
 		}
-		if ev.FilePath != "/etc/shadow" {
-			t.Errorf("file_path = %q", ev.FilePath)
-		}
-		mustValidate(t, ev)
 	})
+}
 
-	t.Run("file_operation_write", func(t *testing.T) {
-		// Neutral tool_name again: only operation="create" should drive file.write.
-		// If the operation attribute were ignored, this neutral name would default
-		// to file.read and the test would fail.
-		rec := recBuilder{attrs: [][]byte{
-			eventNameAttr(geminiFileOperation),
-			kv(attrAliasToolName, "fs_tool"),
-			kv(attrOperation, "create"),
-			kv(attrPathAlt, "/tmp/backdoor.sh"),
-		}}.build()
-		ev := mustMap(t, resource, rec)
-		if ev.EventType != model.EventFileWrite {
-			t.Errorf("event_type = %q, want file.write from operation alone", ev.EventType)
-		}
-		if ev.FilePath != "/tmp/backdoor.sh" {
-			t.Errorf("file_path = %q", ev.FilePath)
-		}
-		mustValidate(t, ev)
-	})
+func TestGeminiQwenFileOperationDoesNotDuplicateToolCall(t *testing.T) {
+	tests := []struct {
+		name         string
+		service      string
+		toolEvent    string
+		fileEvent    string
+		functionName string
+		functionArgs string
+		wantAgent    string
+	}{
+		{"gemini", "gemini-cli", geminiToolCall, geminiFileOperation, "write_file", `{"file_path":"/tmp/gemini.txt"}`, model.AgentGeminiCLI},
+		{"qwen", "qwen-code", qwenToolCall, qwenFileOperation, "WriteFile", `{"file_path":"/tmp/qwen.txt"}`, model.AgentQwenCode},
+	}
 
-	t.Run("file_operation_path_from_function_args", func(t *testing.T) {
-		// No top-level path attribute: the file path must be recovered from the
-		// function_args JSON object's file_path field.
-		rec := recBuilder{attrs: [][]byte{
-			eventNameAttr(geminiFileOperation),
-			kv(attrAliasToolName, "fs_tool"),
-			kv(attrOperation, "update"),
-			kv(attrFunctionArgs, `{"file_path":"/tmp/payload.sh","content":"x"}`),
-		}}.build()
-		ev := mustMap(t, resource, rec)
-		if ev.EventType != model.EventFileWrite {
-			t.Errorf("event_type = %q, want file.write", ev.EventType)
-		}
-		if ev.FilePath != "/tmp/payload.sh" {
-			t.Errorf("file_path = %q, want it recovered from function_args", ev.FilePath)
-		}
-		mustValidate(t, ev)
-	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ids := []string{"ev-tool", "ev-file"}
+			toolCall := recBuilder{attrs: [][]byte{
+				eventNameAttr(tc.toolEvent),
+				kv(attrFunctionName, tc.functionName),
+				kv(attrFunctionArgs, tc.functionArgs),
+				kvAny(attrSuccess, anyBool(true)),
+			}}.build()
+			fileOperation := recBuilder{attrs: [][]byte{
+				eventNameAttr(tc.fileEvent),
+				kv(attrAliasToolName, tc.functionName),
+				kv("operation", "create"),
+			}}.build()
 
-	t.Run("file_operation_unknown_skips", func(t *testing.T) {
-		rec := recBuilder{attrs: [][]byte{
-			eventNameAttr(geminiFileOperation),
-			kv(attrAliasToolName, "fs_tool"),
-			kv(attrOperation, "future_operation"),
-		}}.build()
-		if res := mapOne(t, resource, rec); res.Mapped {
-			t.Fatalf("unknown file operation mapped as %q", res.Event.EventType)
-		}
-	})
+			results, err := MapRecords(
+				exportRequest([][]byte{kv(attrServiceName, tc.service)}, toolCall, fileOperation),
+				func(i int) string { return ids[i] },
+			)
+			if err != nil {
+				t.Fatalf("MapRecords: %v", err)
+			}
+			if len(results) != 2 || !results[0].Mapped || results[1].Mapped || !results[1].Ignored {
+				t.Fatalf("map results = %+v", results)
+			}
+			ev := results[0].Event
+			if ev.EventType != model.EventFileWrite || ev.SourceAgent != tc.wantAgent || ev.FilePath == "" {
+				t.Fatalf("canonical file event = %+v", ev)
+			}
+			mustValidate(t, ev)
+		})
+	}
 }
 
 func TestQwenAliases(t *testing.T) {

--- a/internal/otel/otel.go
+++ b/internal/otel/otel.go
@@ -98,15 +98,15 @@ const (
 	attrEventTimestamp      = "event.timestamp"
 )
 
-// MapResult is the outcome of mapping one OTLP record. Mapped is true when the
-// record classified onto an existing event_type; when false the record had no
-// analog in numbat's vocabulary and the caller skips it (see Map). Event is
-// meaningful only when Mapped is true.
+// MapResult is the outcome of mapping one OTLP record. Mapped identifies a
+// normalized event; Ignored identifies known supplemental telemetry that must
+// not count as a rejected record. Event is meaningful only when Mapped is true.
 type MapResult struct {
-	Event  model.Event
-	Mapped bool
+	Event   model.Event
+	Mapped  bool
+	Ignored bool
 	// SourceAgent is the agent the record's service.name resolved to, returned
-	// even for a skipped record so the caller can label a skip diagnostic.
+	// even for a skipped or ignored record.
 	SourceAgent string
 }
 
@@ -189,6 +189,10 @@ func serviceName(a attrs) string {
 func mapRecord(resourceAttrs []keyValue, rec logRecord, eventID string) MapResult {
 	a := newAttrs(resourceAttrs, rec.attributes)
 	sourceAgent := serviceName(a)
+	name := eventName(&a, rec)
+	if name == geminiFileOperation || name == qwenFileOperation {
+		return MapResult{Ignored: true, SourceAgent: sourceAgent}
+	}
 
 	ev := model.Event{
 		SchemaVersion: model.SchemaVersion,
@@ -342,6 +346,9 @@ func classifyTool(ev *model.Event, a *attrs, rec logRecord) {
 		ev.Tags = append(ev.Tags, model.TagNetwork)
 		if server, tool, ok := splitMCPName(name); ok {
 			ev.MCPServer, ev.MCPTool = server, tool
+		}
+		if errored(a, rec) {
+			ev.Tags = append(ev.Tags, model.TagToolError)
 		}
 		return
 	}

--- a/internal/otel/otel_test.go
+++ b/internal/otel/otel_test.go
@@ -488,6 +488,21 @@ func TestMapNetworkIndicator(t *testing.T) {
 	}
 }
 
+func TestMapFailedNetworkIndicatorTagged(t *testing.T) {
+	rec := recBuilder{attrs: [][]byte{
+		kv(attrServiceName, "claude-code"),
+		kv(attrGenAIToolName, "WebFetch"),
+		kv(attrURLFull, "https://example.com/data"),
+		kv("error.type", "timeout"),
+	}}.build()
+	ev := mapOne(t, nil, rec).Event
+	if ev.EventType != model.EventNetworkIndicator || len(ev.Tags) != 2 ||
+		!hasTag(ev, model.TagNetwork) || !hasTag(ev, model.TagToolError) {
+		t.Fatalf("failed network event = %+v", ev)
+	}
+	mustValidate(t, ev)
+}
+
 // Regression: a url.full that is not an absolute http(s) URL with a
 // host must NOT be promoted into Event.URL. file:///etc/passwd leaves URL empty
 // (kept in ContentPreview); the event is still a network.indicator tagged network.


### PR DESCRIPTION
## Summary
- stop emitting duplicate generic and vendor-specific file events
- keep vendor-native events as source evidence while normalizing once
- report unsupported OTLP records through collector diagnostics

## Validation
- `go test ./internal/otel ./internal/model ./cmd/numbat`