### PR TITLE
Preserve structured case evidence integrity

### DIFF
--- a/cmd/numbat/case.go
+++ b/cmd/numbat/case.go
@@ -48,7 +48,8 @@ findings, hook enforcement decisions, the events named by their cited_event_ids,
 and a manifest of sha256 digests.
 By default no evidence file contents are copied; only references and digests
 travel. --include-raw-evidence copies the cited files verbatim, and
---include-redacted-evidence copies them with each line redacted.
+--include-redacted-evidence copies plain-text or valid, uncompressed JSON evidence
+with best-effort secret masking; review it before sharing.
 
 verify checks a bundle against its manifest: every listed file must match its
 digest and record count, and the bundle may contain nothing unlisted.
@@ -70,7 +71,7 @@ func newCaseBuildFlagSet(output io.Writer, opts *caseBuildOptions) *flag.FlagSet
 	fs.StringVar(&opts.out, "out", opts.out, "bundle directory to create (must not exist)")
 	fs.Var(&opts.from, "from", "captured NDJSON record-stream file to read (repeatable; required)")
 	fs.BoolVar(&opts.includeRaw, "include-raw-evidence", false, "copy cited evidence files verbatim into the bundle (opt-in: may include secrets/transcripts)")
-	fs.BoolVar(&opts.includeRedacted, "include-redacted-evidence", false, "copy cited evidence files with each line redacted")
+	fs.BoolVar(&opts.includeRedacted, "include-redacted-evidence", false, "copy cited plain-text or uncompressed JSON evidence with best-effort secret masking (review before sharing)")
 	fs.Usage = func() {
 		_, _ = fmt.Fprintln(output, "usage: numbat case build <case-id> --from FILE [--from FILE ...] [-o|--out DIR] [--include-raw-evidence|--include-redacted-evidence]")
 		fs.PrintDefaults()

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -758,9 +758,11 @@ cited event records, the build succeeds
 with an incomplete-events warning; capture `--emit all` when the bundle should
 contain both. Inputs use the current record schema; other schema versions are
 skipped with a warning, and a source line that reaches the 8 MiB input cap fails
-the build. The
-manifest also records the build time. `case verify` is an integrity check, not a
-re-scan: it re-hashes a bundle against its manifest
+the build. The manifest records the build time and `evidence_mode` (`none`,
+`raw`, or `redacted`). Evidence entries carry separate hashes for the source
+bytes at copy time and the bytes stored in the bundle, so a redacted copy is
+never mistaken for the original artifact. `case verify` is an integrity check,
+not a re-scan: it re-hashes a bundle against its manifest
 — every listed file must match its digest, record files must match their record
 counts, and nothing unlisted may be present — but it never re-runs rules.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -798,9 +798,9 @@ travel. `--include-raw-evidence` copies the cited files verbatim (they can hold
 `.env` contents, keys, or transcripts — share with care), and
 `--include-redacted-evidence` applies best-effort masking to plain text and
 rewrites valid, uncompressed JSON/NDJSON without breaking its syntax. Malformed,
-compressed, binary, or oversized inputs are skipped with a warning. Redacted
-copies can still contain sensitive data; review them before sharing. The
-manifest digests prove *integrity* —
+unsafe-to-redact, compressed, binary, or oversized inputs are skipped with a
+warning. Redacted copies can still contain sensitive data; review them before
+sharing. The manifest digests prove *integrity* —
 that the bundle is self-consistent and unmodified since it was written. These
 digests do not prove authenticity: bundles are unsigned, and anyone can rebuild
 a manifest.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -779,7 +779,8 @@ case-scoped findings to bundle.
                              must not exist)
 --include-raw-evidence       copy cited evidence files verbatim (opt-in; may
                              include secrets/transcripts)
---include-redacted-evidence  copy cited evidence files with each line redacted
+--include-redacted-evidence  copy cited plain-text or uncompressed JSON evidence
+                             with best-effort secret masking; review before sharing
                              (mutually exclusive with --include-raw-evidence)
 ```
 
@@ -795,8 +796,11 @@ numbat case verify inv-42.numbat
 By default no evidence file contents are copied — only references and digests
 travel. `--include-raw-evidence` copies the cited files verbatim (they can hold
 `.env` contents, keys, or transcripts — share with care), and
-`--include-redacted-evidence` copies them with each line run through the same
-redaction pipeline used for findings. The manifest digests prove *integrity* —
+`--include-redacted-evidence` applies best-effort masking to plain text and
+rewrites valid, uncompressed JSON/NDJSON without breaking its syntax. Malformed,
+compressed, binary, or oversized inputs are skipped with a warning. Redacted
+copies can still contain sensitive data; review them before sharing. The
+manifest digests prove *integrity* —
 that the bundle is self-consistent and unmodified since it was written. These
 digests do not prove authenticity: bundles are unsigned, and anyone can rebuild
 a manifest.

--- a/internal/casebundle/build.go
+++ b/internal/casebundle/build.go
@@ -10,8 +10,7 @@
 //
 // Safe by default: a bundle contains findings, cited events, and digests —
 // never copies of raw evidence files. Copying cited files (which can hold
-// .env contents, keys, or transcripts) is a per-build opt-in, raw or with
-// each line redacted.
+// .env contents, keys, or transcripts) is a per-build opt-in, raw or redacted.
 //
 // The manifest's digests prove integrity: that the bundle is self-consistent
 // and unmodified since it was written. They do not prove authenticity or
@@ -28,11 +27,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/perplexityai/numbat/internal/model"
 	"github.com/perplexityai/numbat/internal/output"
@@ -43,8 +44,12 @@ import (
 // maxRecordLine bounds one NDJSON input line, matching the fixture reader's
 // cap so a corrupt stream cannot exhaust memory.
 const (
-	maxRecordLine     = 8 * 1024 * 1024
-	maxResultWarnings = 1_000
+	maxRecordLine                 = 8 * 1024 * 1024
+	maxEvidenceLine               = 16 * 1024 * 1024
+	maxJSONEvidenceBytes          = 64 * 1024 * 1024
+	maxResultWarnings             = 100
+	maxGeneralResultWarnings      = 80
+	maxMalformedWarningsPerSource = 3
 )
 
 // EvidenceMode selects whether cited evidence files are copied into the
@@ -55,10 +60,8 @@ const (
 	EvidenceNone EvidenceMode = iota
 	// EvidenceRaw copies each cited file verbatim into evidence/.
 	EvidenceRaw
-	// EvidenceRedacted copies each cited file with every line passed through
-	// the same redaction findings use, so secret values are masked while the
-	// structure stays reviewable. The manifest digest covers the redacted
-	// bytes (the raw source is not retained to hash).
+	// EvidenceRedacted applies best-effort masking while keeping supported
+	// structured evidence parseable.
 	EvidenceRedacted
 )
 
@@ -91,12 +94,20 @@ type Result struct {
 }
 
 func (r *Result) warn(msg string) {
-	if len(r.Warnings) < maxResultWarnings-1 {
+	r.appendWarning(msg, maxGeneralResultWarnings, "additional warnings suppressed")
+}
+
+func (r *Result) warnEvidence(msg string) {
+	r.appendWarning(msg, maxResultWarnings, "additional evidence warnings suppressed")
+}
+
+func (r *Result) appendWarning(msg string, limit int, suppressed string) {
+	if len(r.Warnings) < limit-1 {
 		r.Warnings = append(r.Warnings, msg)
 		return
 	}
-	if len(r.Warnings) == maxResultWarnings-1 {
-		r.Warnings = append(r.Warnings, "additional warnings suppressed")
+	if len(r.Warnings) == limit-1 {
+		r.Warnings = append(r.Warnings, suppressed)
 	}
 }
 
@@ -504,6 +515,7 @@ func eachLine(sources []string, res *Result, warnMalformed bool, fn func(p probe
 		sc := bufio.NewScanner(f)
 		sc.Buffer(make([]byte, 0, 64*1024), maxRecordLine)
 		line := 0
+		malformed := 0
 		for sc.Scan() {
 			line++
 			raw := sc.Bytes()
@@ -513,7 +525,10 @@ func eachLine(sources []string, res *Result, warnMalformed bool, fn func(p probe
 			var p probe
 			if err := json.Unmarshal(raw, &p); err != nil {
 				if warnMalformed {
-					res.warn(fmt.Sprintf("%s:%d: not a record: %v", src, line, err))
+					malformed++
+					if malformed <= maxMalformedWarningsPerSource {
+						res.warn(fmt.Sprintf("%s:%d: not a record: %v", src, line, err))
+					}
 				}
 				continue
 			}
@@ -525,6 +540,9 @@ func eachLine(sources []string, res *Result, warnMalformed bool, fn func(p probe
 		}
 		if scanErr != nil {
 			return fmt.Errorf("casebundle: read %q: %w", src, scanErr)
+		}
+		if suppressed := malformed - maxMalformedWarningsPerSource; suppressed > 0 {
+			res.warn(fmt.Sprintf("%s: %d additional malformed records suppressed", src, suppressed))
 		}
 	}
 	return nil
@@ -574,11 +592,10 @@ func writeRecords(dir, name string, recs []record) (ManifestFile, error) {
 // copyEvidence copies each cited artifact into evidence/, raw or redacted.
 // Paths are deduplicated and processed in sorted order. A missing or
 // unreadable cited file is a warning — the refs in the findings still locate
-// it on the source machine — and, in raw mode, a copy whose digest does not
-// equal every recorded digest on citing refs warns that the artifact changed
-// after the finding was made. If different findings recorded conflicting
-// digests, any copied value necessarily drifts from at least one of them and
-// therefore warns.
+// it on the source machine. A source digest that does not equal every recorded
+// digest on citing refs warns that the artifact changed after the finding was
+// made. If different findings recorded conflicting digests, any source value
+// necessarily drifts from at least one of them and therefore warns.
 func copyEvidence(opts Options, refs map[model.Evidence]struct{}, res *Result) ([]ManifestFile, error) {
 	byPath := map[string]map[string]struct{}{} // local path -> distinct non-empty recorded sha256s
 	for ref := range refs {
@@ -607,14 +624,14 @@ func copyEvidence(opts Options, refs map[model.Evidence]struct{}, res *Result) (
 	}
 	var files []ManifestFile
 	for _, src := range paths {
-		mf, err := copyOneEvidence(evDir, src, opts.Evidence)
+		mf, sourceSHA256, err := copyOneEvidence(evDir, src, opts.Evidence)
 		if err != nil {
-			res.warn(fmt.Sprintf("evidence %q: %v", src, err))
+			res.warnEvidence(fmt.Sprintf("evidence %q: %v", src, err))
 			continue
 		}
 		recorded := sortedDigests(byPath[src])
-		if opts.Evidence == EvidenceRaw && digestDiffers(recorded, mf.SHA256) {
-			res.warn(evidenceDriftWarning(src, recorded, mf.SHA256))
+		if digestDiffers(recorded, sourceSHA256) {
+			res.warnEvidence(evidenceDriftWarning(src, recorded, sourceSHA256))
 		}
 		files = append(files, mf)
 	}
@@ -640,8 +657,8 @@ func sortedDigests(set map[string]struct{}) []string {
 
 func digestDiffers(recorded []string, copied string) bool {
 	for _, digest := range recorded {
-		// Warn if the copied bytes drift from ANY recorded digest; a mixed set of
-		// recorded digests therefore always warns, even if one digest matches.
+		// Warn if the source bytes drift from ANY recorded digest. A mixed set
+		// therefore always warns, even if one digest matches.
 		if digest != copied {
 			return true
 		}
@@ -649,11 +666,11 @@ func digestDiffers(recorded []string, copied string) bool {
 	return false
 }
 
-func evidenceDriftWarning(src string, recorded []string, copied string) string {
+func evidenceDriftWarning(src string, recorded []string, current string) string {
 	if len(recorded) == 1 {
-		return fmt.Sprintf("evidence %q: content changed since the finding (recorded sha256 %s, copied %s)", src, recorded[0], copied)
+		return fmt.Sprintf("evidence %q: content changed since the finding (recorded sha256 %s, source at copy time %s)", src, recorded[0], current)
 	}
-	return fmt.Sprintf("evidence %q: content changed since the finding (recorded sha256s [%s], copied %s)", src, strings.Join(recorded, ", "), copied)
+	return fmt.Sprintf("evidence %q: content changed since the finding (recorded sha256s [%s], source at copy time %s)", src, strings.Join(recorded, ", "), current)
 }
 
 // copyOneEvidence writes one evidence copy and returns its manifest entry.
@@ -661,32 +678,33 @@ func evidenceDriftWarning(src string, recorded []string, copied string) string {
 // two cited files sharing a basename never collide. The basename is reduced to
 // a portable ASCII segment so odd local filenames do not leak control
 // characters into the bundle.
-func copyOneEvidence(evDir, src string, mode EvidenceMode) (ManifestFile, error) {
+func copyOneEvidence(evDir, src string, mode EvidenceMode) (ManifestFile, string, error) {
 	in, err := openRegularFile(src)
 	if err != nil {
-		return ManifestFile{}, err
+		return ManifestFile{}, "", err
 	}
 
 	name := evidenceCopyName(src)
 	out, err := os.OpenFile(filepath.Join(evDir, name), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
 		_ = in.Close()
-		return ManifestFile{}, err
+		return ManifestFile{}, "", err
 	}
 
-	h := sha256.New()
-	w := io.MultiWriter(out, h)
-	copyErr := errors.Join(copyContent(w, in, mode), in.Close(), out.Close())
+	outputHash := sha256.New()
+	sourceHash := sha256.New()
+	w := io.MultiWriter(out, outputHash)
+	copyErr := errors.Join(copyContent(w, io.TeeReader(in, sourceHash), mode, src), in.Close(), out.Close())
 	if copyErr != nil {
 		// Never leave a partial copy behind a clean manifest.
 		_ = os.Remove(filepath.Join(evDir, name))
-		return ManifestFile{}, copyErr
+		return ManifestFile{}, "", copyErr
 	}
 	return ManifestFile{
 		Path:       "evidence/" + name,
-		SHA256:     hex.EncodeToString(h.Sum(nil)),
+		SHA256:     hex.EncodeToString(outputHash.Sum(nil)),
 		SourcePath: src,
-	}, nil
+	}, hex.EncodeToString(sourceHash.Sum(nil)), nil
 }
 
 func evidenceCopyName(src string) string {
@@ -724,16 +742,107 @@ func sanitizeEvidenceBase(base string) string {
 	return cleaned
 }
 
-// copyContent streams the source verbatim, or line-by-line through
-// redact.String when the redacted copy was requested. Redacted copies preserve
-// the source's line endings and final-newline shape; only each line body is
-// transformed.
-func copyContent(w io.Writer, in io.Reader, mode EvidenceMode) error {
+// copyContent streams raw evidence verbatim. Redacted JSON is parsed before it
+// is rewritten so masking cannot corrupt its syntax; supported text remains
+// line-oriented and preserves line endings.
+func copyContent(w io.Writer, in io.Reader, mode EvidenceMode, src string) error {
 	if mode == EvidenceRaw {
 		_, err := io.Copy(w, in)
 		return err
 	}
+	lower := strings.ToLower(filepath.Base(src))
+	base, compressed := trimCompressionSuffix(lower)
+	switch {
+	case compressed:
+		return fmt.Errorf("redacted evidence does not support compressed input; decompress the source first or include it raw")
+	case isJSONLinesName(base):
+		return copyRedactedJSONLines(w, in)
+	case strings.HasSuffix(base, ".json"):
+		return copyRedactedJSON(w, in)
+	default:
+		return copyRedactedText(w, in)
+	}
+}
+
+func trimCompressionSuffix(name string) (string, bool) {
+	for _, suffix := range []string{".zst", ".gz", ".bz2", ".xz", ".zip"} {
+		if strings.HasSuffix(name, suffix) {
+			return strings.TrimSuffix(name, suffix), true
+		}
+	}
+	return name, false
+}
+
+func isJSONLinesName(name string) bool {
+	return strings.HasSuffix(name, ".jsonl") || strings.HasSuffix(name, ".ndjson") ||
+		strings.Contains(name, ".jsonl.") || strings.Contains(name, ".ndjson.")
+}
+
+func copyRedactedJSONLines(w io.Writer, in io.Reader) error {
 	r := bufio.NewReaderSize(in, 64*1024)
+	lineNumber := 0
+	for {
+		line, err := readEvidenceLine(r)
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		lineNumber++
+		body, eol := splitLineEnding(line)
+		if strings.TrimSpace(body) == "" {
+			if _, err := io.WriteString(w, body+eol); err != nil {
+				return err
+			}
+			continue
+		}
+		redacted, err := redact.JSON([]byte(body))
+		if err != nil {
+			return fmt.Errorf("line %d: invalid JSON: %w", lineNumber, err)
+		}
+		if _, err := w.Write(redacted); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(w, eol); err != nil {
+			return err
+		}
+	}
+}
+
+func copyRedactedJSON(w io.Writer, in io.Reader) error {
+	raw, err := io.ReadAll(io.LimitReader(in, maxJSONEvidenceBytes+1))
+	if err != nil {
+		return err
+	}
+	if len(raw) > maxJSONEvidenceBytes {
+		return fmt.Errorf("JSON evidence exceeds %d bytes", maxJSONEvidenceBytes)
+	}
+	redacted, err := redact.JSON(raw)
+	if err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
+	}
+	if _, err := w.Write(redacted); err != nil {
+		return err
+	}
+	switch {
+	case bytes.HasSuffix(raw, []byte("\r\n")):
+		_, err = io.WriteString(w, "\r\n")
+	case bytes.HasSuffix(raw, []byte("\n")):
+		_, err = io.WriteString(w, "\n")
+	}
+	return err
+}
+
+func copyRedactedText(w io.Writer, in io.Reader) error {
+	r := bufio.NewReaderSize(in, 64*1024)
+	sample, err := r.Peek(512)
+	if err != nil && err != io.EOF {
+		return err
+	}
+	if contentType := http.DetectContentType(sample); !strings.HasPrefix(contentType, "text/") {
+		return fmt.Errorf("redacted evidence only supports UTF-8 plain text or JSON (detected %s)", contentType)
+	}
 	for {
 		line, err := readEvidenceLine(r)
 		if err == io.EOF {
@@ -743,6 +852,9 @@ func copyContent(w io.Writer, in io.Reader, mode EvidenceMode) error {
 			return err
 		}
 		body, eol := splitLineEnding(line)
+		if !utf8.ValidString(body) || strings.IndexByte(body, 0) >= 0 {
+			return fmt.Errorf("redacted evidence only supports UTF-8 plain text or JSON")
+		}
 		if _, err := io.WriteString(w, redact.String(body)+eol); err != nil {
 			return err
 		}
@@ -754,8 +866,8 @@ func readEvidenceLine(r *bufio.Reader) (string, error) {
 	for {
 		part, err := r.ReadSlice('\n')
 		line = append(line, part...)
-		if len(line) > maxRecordLine+len("\r\n") {
-			return "", fmt.Errorf("line exceeds %d bytes", maxRecordLine)
+		if len(line) > maxEvidenceLine+len("\r\n") {
+			return "", fmt.Errorf("line exceeds %d bytes", maxEvidenceLine)
 		}
 		switch err {
 		case nil:

--- a/internal/casebundle/build.go
+++ b/internal/casebundle/build.go
@@ -799,7 +799,7 @@ func copyRedactedJSONLines(w io.Writer, in io.Reader) error {
 		}
 		redacted, err := redact.JSON([]byte(body))
 		if err != nil {
-			return fmt.Errorf("line %d: invalid JSON: %w", lineNumber, err)
+			return fmt.Errorf("line %d: cannot safely redact JSON: %w", lineNumber, err)
 		}
 		if _, err := w.Write(redacted); err != nil {
 			return err
@@ -820,7 +820,7 @@ func copyRedactedJSON(w io.Writer, in io.Reader) error {
 	}
 	redacted, err := redact.JSON(raw)
 	if err != nil {
-		return fmt.Errorf("invalid JSON: %w", err)
+		return fmt.Errorf("cannot safely redact JSON: %w", err)
 	}
 	if _, err := w.Write(redacted); err != nil {
 		return err

--- a/internal/casebundle/build.go
+++ b/internal/casebundle/build.go
@@ -65,6 +65,19 @@ const (
 	EvidenceRedacted
 )
 
+func (m EvidenceMode) String() string {
+	switch m {
+	case EvidenceNone:
+		return "none"
+	case EvidenceRaw:
+		return "raw"
+	case EvidenceRedacted:
+		return "redacted"
+	default:
+		return ""
+	}
+}
+
 // Options configures one bundle build.
 type Options struct {
 	// CaseID selects the findings to bundle (their case_id field).
@@ -119,6 +132,7 @@ type Manifest struct {
 	CreatedAt     string         `json:"created_at"`
 	Tool          string         `json:"tool"`
 	ToolVersion   string         `json:"tool_version"`
+	EvidenceMode  string         `json:"evidence_mode"`
 	Files         []ManifestFile `json:"files"`
 }
 
@@ -131,6 +145,8 @@ type ManifestFile struct {
 	Records int `json:"records,omitempty"`
 	// SourcePath is the local path an evidence copy was taken from.
 	SourcePath string `json:"source_path,omitempty"`
+	// SourceSHA256 hashes the source bytes before any redaction.
+	SourceSHA256 string `json:"source_sha256,omitempty"`
 }
 
 // manifestName is the one non-record file every bundle carries.
@@ -700,11 +716,14 @@ func copyOneEvidence(evDir, src string, mode EvidenceMode) (ManifestFile, string
 		_ = os.Remove(filepath.Join(evDir, name))
 		return ManifestFile{}, "", copyErr
 	}
+	outputSHA256 := hex.EncodeToString(outputHash.Sum(nil))
+	sourceSHA256 := hex.EncodeToString(sourceHash.Sum(nil))
 	return ManifestFile{
-		Path:       "evidence/" + name,
-		SHA256:     hex.EncodeToString(outputHash.Sum(nil)),
-		SourcePath: src,
-	}, hex.EncodeToString(sourceHash.Sum(nil)), nil
+		Path:         "evidence/" + name,
+		SHA256:       outputSHA256,
+		SourcePath:   src,
+		SourceSHA256: sourceSHA256,
+	}, sourceSHA256, nil
 }
 
 func evidenceCopyName(src string) string {
@@ -909,6 +928,7 @@ func writeManifest(opts Options, files []ManifestFile) error {
 		CreatedAt:     now.UTC().Format(time.RFC3339Nano),
 		Tool:          model.ToolName,
 		ToolVersion:   version.String(),
+		EvidenceMode:  opts.Evidence.String(),
 		Files:         files,
 	}
 	b, err := json.MarshalIndent(m, "", "  ")

--- a/internal/casebundle/casebundle_test.go
+++ b/internal/casebundle/casebundle_test.go
@@ -168,7 +168,7 @@ func TestBuildBundleShape(t *testing.T) {
 	if err := json.Unmarshal(b, &m); err != nil {
 		t.Fatal(err)
 	}
-	if m.CaseID != "case-1" || m.SchemaVersion != "0.2.0" || m.Tool != "numbat" || m.ToolVersion == "" {
+	if m.CaseID != "case-1" || m.SchemaVersion != "0.2.0" || m.Tool != "numbat" || m.ToolVersion == "" || m.EvidenceMode != "none" {
 		t.Fatalf("manifest = %+v", m)
 	}
 	if m.CreatedAt != "2026-06-10T12:00:00Z" {
@@ -848,8 +848,14 @@ func TestEvidenceRawCopy(t *testing.T) {
 			ev = &m.Files[i]
 		}
 	}
+	if m.EvidenceMode != "raw" {
+		t.Fatalf("evidence_mode = %q, want raw", m.EvidenceMode)
+	}
 	if ev == nil || ev.SourcePath != artifact || !strings.HasSuffix(ev.Path, "-session.jsonl") {
 		t.Fatalf("evidence manifest entry = %+v", ev)
+	}
+	if ev.SourceSHA256 != sha256StringHex(content) || ev.SHA256 != ev.SourceSHA256 {
+		t.Fatalf("raw evidence hashes = stored %q source %q", ev.SHA256, ev.SourceSHA256)
 	}
 	copied, err := os.ReadFile(filepath.Join(opts.Out, filepath.FromSlash(ev.Path)))
 	if err != nil {
@@ -966,7 +972,8 @@ func TestEvidenceCopyRejectsSymlinkSources(t *testing.T) {
 func TestEvidenceRedactedCopyMasksSecrets(t *testing.T) {
 	artifact := filepath.Join(t.TempDir(), "session.log")
 	secret := "GITHUB_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz0123456789"
-	if err := os.WriteFile(artifact, []byte("before\n"+secret+"\nafter\n"), 0o600); err != nil {
+	source := "before\n" + secret + "\nafter\n"
+	if err := os.WriteFile(artifact, []byte(source), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	opts := buildOpts(evidenceStream(t, artifact, ""))
@@ -987,6 +994,26 @@ func TestEvidenceRedactedCopyMasksSecrets(t *testing.T) {
 	}
 	if !strings.Contains(string(copied), "before\n") || !strings.Contains(string(copied), "after\n") {
 		t.Fatalf("redacted copy lost benign lines: %q", copied)
+	}
+	var m Manifest
+	manifest, err := os.ReadFile(filepath.Join(opts.Out, manifestName))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if err := json.Unmarshal(manifest, &m); err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	if m.EvidenceMode != "redacted" {
+		t.Fatalf("evidence_mode = %q, want redacted", m.EvidenceMode)
+	}
+	var evidence ManifestFile
+	for _, mf := range m.Files {
+		if strings.HasPrefix(mf.Path, "evidence/") {
+			evidence = mf
+		}
+	}
+	if evidence.SourceSHA256 != sha256StringHex(source) || evidence.SHA256 == evidence.SourceSHA256 {
+		t.Fatalf("redacted evidence hashes = stored %q source %q", evidence.SHA256, evidence.SourceSHA256)
 	}
 	if v, err := Verify(opts.Out); err != nil || !v.OK() {
 		t.Fatalf("redacted bundle must verify: %+v, %v", v, err)

--- a/internal/casebundle/casebundle_test.go
+++ b/internal/casebundle/casebundle_test.go
@@ -1093,7 +1093,7 @@ func TestEvidenceRedactedRejectsUnsafeStructuredInput(t *testing.T) {
 		body string
 		want string
 	}{
-		{"malformed JSONL", ".jsonl", `{"token":`, "invalid JSON"},
+		{"malformed JSONL", ".jsonl", `{"token":`, "cannot safely redact JSON"},
 		{"credential in JSON key", ".json", `{"ghp_abcdefghijklmnopqrstuvwxyz0123456789":"value"}`, "object key"},
 		{"compressed JSONL", ".jsonl.zst", "compressed", "does not support compressed input"},
 		{"compressed retained archive", ".jsonl.deleted.2026-07-23T10-11-12Z.gz", "compressed", "does not support compressed input"},

--- a/internal/casebundle/casebundle_test.go
+++ b/internal/casebundle/casebundle_test.go
@@ -614,16 +614,41 @@ func TestBuildMalformedLineWarnsAndContinues(t *testing.T) {
 	}
 }
 
+func TestBuildMalformedLineWarningsAreSummarizedPerSource(t *testing.T) {
+	evidence := ref("/a/t.jsonl", 1)
+	lines := make([]string, maxMalformedWarningsPerSource+5)
+	for i := range lines {
+		lines[i] = "not-json"
+	}
+	lines = append(lines,
+		finding(t, "fnd-a", "case-1", "2026-06-02T10:00:00Z", evidence),
+		event(t, "event-for-fnd-a", "2026-06-02T09:59:59Z", evidence),
+	)
+	opts := buildOpts(writeStream(t, lines...))
+	opts.Out = filepath.Join(t.TempDir(), "case.numbat")
+	res := mustBuild(t, opts)
+	if len(res.Warnings) != maxMalformedWarningsPerSource+1 {
+		t.Fatalf("warnings = %v", res.Warnings)
+	}
+	if got := res.Warnings[len(res.Warnings)-1]; !strings.Contains(got, "5 additional malformed records suppressed") {
+		t.Fatalf("summary warning = %q", got)
+	}
+}
+
 func TestResultWarningsAreBounded(t *testing.T) {
 	var res Result
 	for i := 0; i < maxResultWarnings+100; i++ {
 		res.warn(fmt.Sprintf("warning %d", i))
 	}
-	if len(res.Warnings) != maxResultWarnings {
-		t.Fatalf("warnings = %d, want cap %d", len(res.Warnings), maxResultWarnings)
+	if len(res.Warnings) != maxGeneralResultWarnings {
+		t.Fatalf("warnings = %d, want cap %d", len(res.Warnings), maxGeneralResultWarnings)
 	}
 	if got := res.Warnings[len(res.Warnings)-1]; got != "additional warnings suppressed" {
 		t.Fatalf("last warning = %q", got)
+	}
+	res.warnEvidence("evidence omitted")
+	if got := res.Warnings[len(res.Warnings)-1]; got != "evidence omitted" {
+		t.Fatalf("evidence warning was suppressed: %v", res.Warnings)
 	}
 }
 
@@ -838,17 +863,19 @@ func TestEvidenceRawCopy(t *testing.T) {
 	}
 }
 
-func TestEvidenceRawCopyWarnsOnHashDrift(t *testing.T) {
+func TestEvidenceCopyWarnsOnHashDrift(t *testing.T) {
 	artifact := filepath.Join(t.TempDir(), "session.jsonl")
-	if err := os.WriteFile(artifact, []byte("changed since the finding\n"), 0o600); err != nil {
+	if err := os.WriteFile(artifact, []byte(`{"text":"changed since the finding"}`+"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	opts := buildOpts(evidenceStream(t, artifact, strings.Repeat("a", 64)))
-	opts.Out = filepath.Join(t.TempDir(), "case.numbat")
-	opts.Evidence = EvidenceRaw
-	res := mustBuild(t, opts)
-	if len(res.Warnings) != 1 || !strings.Contains(res.Warnings[0], "changed since the finding") {
-		t.Fatalf("warnings = %v, want a hash-drift warning", res.Warnings)
+	for _, mode := range []EvidenceMode{EvidenceRaw, EvidenceRedacted} {
+		opts := buildOpts(evidenceStream(t, artifact, strings.Repeat("a", 64)))
+		opts.Out = filepath.Join(t.TempDir(), "case.numbat")
+		opts.Evidence = mode
+		res := mustBuild(t, opts)
+		if len(res.Warnings) != 1 || !strings.Contains(res.Warnings[0], "changed since the finding") {
+			t.Fatalf("mode %d warnings = %v, want a hash-drift warning", mode, res.Warnings)
+		}
 	}
 }
 
@@ -878,7 +905,7 @@ func TestEvidenceRawCopyWarnsOnConflictingRecordedDigests(t *testing.T) {
 	if res.EvidenceFiles != 1 {
 		t.Fatalf("evidence files = %d, want 1", res.EvidenceFiles)
 	}
-	want := fmt.Sprintf("evidence %q: content changed since the finding (recorded sha256s [%s, %s], copied %s)", artifact, otherSHA, currentSHA, currentSHA)
+	want := fmt.Sprintf("evidence %q: content changed since the finding (recorded sha256s [%s, %s], source at copy time %s)", artifact, otherSHA, currentSHA, currentSHA)
 	if len(res.Warnings) != 1 || res.Warnings[0] != want {
 		t.Fatalf("warnings = %v, want %q", res.Warnings, want)
 	}
@@ -937,7 +964,7 @@ func TestEvidenceCopyRejectsSymlinkSources(t *testing.T) {
 }
 
 func TestEvidenceRedactedCopyMasksSecrets(t *testing.T) {
-	artifact := filepath.Join(t.TempDir(), "session.jsonl")
+	artifact := filepath.Join(t.TempDir(), "session.log")
 	secret := "GITHUB_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz0123456789"
 	if err := os.WriteFile(artifact, []byte("before\n"+secret+"\nafter\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -947,7 +974,7 @@ func TestEvidenceRedactedCopyMasksSecrets(t *testing.T) {
 	opts.Evidence = EvidenceRedacted
 	mustBuild(t, opts)
 
-	matches, err := filepath.Glob(filepath.Join(opts.Out, "evidence", "*-session.jsonl"))
+	matches, err := filepath.Glob(filepath.Join(opts.Out, "evidence", "*-session.log"))
 	if err != nil || len(matches) != 1 {
 		t.Fatalf("evidence copies = %v (%v)", matches, err)
 	}
@@ -967,7 +994,7 @@ func TestEvidenceRedactedCopyMasksSecrets(t *testing.T) {
 }
 
 func TestEvidenceRedactedCopyPreservesLineEndings(t *testing.T) {
-	artifact := filepath.Join(t.TempDir(), "session.jsonl")
+	artifact := filepath.Join(t.TempDir(), "session.log")
 	body := "one\r\nGITHUB_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz0123456789\r\ntwo"
 	if err := os.WriteFile(artifact, []byte(body), 0o600); err != nil {
 		t.Fatal(err)
@@ -977,7 +1004,7 @@ func TestEvidenceRedactedCopyPreservesLineEndings(t *testing.T) {
 	opts.Evidence = EvidenceRedacted
 	mustBuild(t, opts)
 
-	matches, err := filepath.Glob(filepath.Join(opts.Out, "evidence", "*-session.jsonl"))
+	matches, err := filepath.Glob(filepath.Join(opts.Out, "evidence", "*-session.log"))
 	if err != nil || len(matches) != 1 {
 		t.Fatalf("evidence copies = %v (%v)", matches, err)
 	}
@@ -988,6 +1015,112 @@ func TestEvidenceRedactedCopyPreservesLineEndings(t *testing.T) {
 	want := "one\r\nGITHUB_TOKEN=[redacted]\r\ntwo"
 	if string(copied) != want {
 		t.Fatalf("redacted copy = %q, want %q", copied, want)
+	}
+}
+
+func TestEvidenceRedactedStructuredFilesStayValid(t *testing.T) {
+	tests := []struct {
+		name string
+		ext  string
+		body string
+	}{
+		{
+			name: "jsonl",
+			ext:  ".jsonl",
+			body: `{"type":"token_count","total_token_usage":{"input_tokens":42}}` + "\r\n" +
+				`{"api_key":"plain-secret","text":"GITHUB_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz0123456789"}`,
+		},
+		{
+			name: "retained jsonl archive",
+			ext:  ".jsonl.deleted.2026-07-23T10-11-12Z",
+			body: `{"type":"message","api_key":"plain-secret"}` + "\n",
+		},
+		{
+			name: "json",
+			ext:  ".json",
+			body: "{\n  \"api_key\": \"plain-secret\",\n  \"count\": 7\n}\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			artifact := filepath.Join(t.TempDir(), "session"+tc.ext)
+			if err := os.WriteFile(artifact, []byte(tc.body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			opts := buildOpts(evidenceStream(t, artifact, sha256StringHex(tc.body)))
+			opts.Out = filepath.Join(t.TempDir(), "case.numbat")
+			opts.Evidence = EvidenceRedacted
+			res := mustBuild(t, opts)
+			if res.EvidenceFiles != 1 || len(res.Warnings) != 0 {
+				t.Fatalf("result = %+v", res)
+			}
+
+			matches, err := filepath.Glob(filepath.Join(opts.Out, "evidence", "*-session"+tc.ext))
+			if err != nil || len(matches) != 1 {
+				t.Fatalf("evidence copies = %v (%v)", matches, err)
+			}
+			copied, err := os.ReadFile(matches[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(copied), "plain-secret") || strings.Contains(string(copied), "ghp_") {
+				t.Fatalf("redacted copy leaked a secret: %s", copied)
+			}
+			if tc.ext == ".json" {
+				if !json.Valid(copied) {
+					t.Fatalf("redacted JSON is invalid: %s", copied)
+				}
+			} else {
+				for _, line := range strings.Split(string(copied), "\r\n") {
+					if !json.Valid([]byte(line)) {
+						t.Fatalf("redacted JSONL line is invalid: %s", line)
+					}
+				}
+			}
+
+			if v, err := Verify(opts.Out); err != nil || !v.OK() {
+				t.Fatalf("bundle must verify: %+v, %v", v, err)
+			}
+		})
+	}
+}
+
+func TestEvidenceRedactedRejectsUnsafeStructuredInput(t *testing.T) {
+	tests := []struct {
+		name string
+		ext  string
+		body string
+		want string
+	}{
+		{"malformed JSONL", ".jsonl", `{"token":`, "invalid JSON"},
+		{"credential in JSON key", ".json", `{"ghp_abcdefghijklmnopqrstuvwxyz0123456789":"value"}`, "object key"},
+		{"compressed JSONL", ".jsonl.zst", "compressed", "does not support compressed input"},
+		{"compressed retained archive", ".jsonl.deleted.2026-07-23T10-11-12Z.gz", "compressed", "does not support compressed input"},
+		{"binary input", ".bin", "\x00\x01\x02\x03", "only supports UTF-8 plain text or JSON"},
+		{"late binary input", ".log", strings.Repeat("a", 600) + "\x00secret", "only supports UTF-8 plain text or JSON"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			artifact := filepath.Join(t.TempDir(), "session"+tc.ext)
+			if err := os.WriteFile(artifact, []byte(tc.body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			opts := buildOpts(evidenceStream(t, artifact, ""))
+			opts.Out = filepath.Join(t.TempDir(), "case.numbat")
+			opts.Evidence = EvidenceRedacted
+			res := mustBuild(t, opts)
+			if res.EvidenceFiles != 0 || len(res.Warnings) != 1 || !strings.Contains(res.Warnings[0], tc.want) {
+				t.Fatalf("result = %+v", res)
+			}
+			if _, err := os.Lstat(filepath.Join(opts.Out, "evidence")); !os.IsNotExist(err) {
+				t.Fatal("failed structured copy left an evidence directory")
+			}
+			if v, err := Verify(opts.Out); err != nil || !v.OK() {
+				t.Fatalf("bundle must verify: %+v, %v", v, err)
+			}
+		})
 	}
 }
 

--- a/internal/casebundle/verify.go
+++ b/internal/casebundle/verify.go
@@ -145,6 +145,11 @@ func validateManifest(m Manifest) []string {
 	if strings.TrimSpace(m.ToolVersion) == "" {
 		problems = append(problems, "manifest: empty tool_version")
 	}
+	switch m.EvidenceMode {
+	case "", "none", "raw", "redacted":
+	default:
+		problems = append(problems, fmt.Sprintf("manifest: invalid evidence_mode %q", m.EvidenceMode))
+	}
 	if _, err := time.Parse(time.RFC3339Nano, m.CreatedAt); err != nil {
 		problems = append(problems, fmt.Sprintf("manifest: invalid created_at %q", m.CreatedAt))
 	}
@@ -161,6 +166,22 @@ func validateManifest(m Manifest) []string {
 	for _, mf := range files {
 		if mf.Path == "findings.ndjson" || mf.Path == "events.ndjson" {
 			present[mf.Path] = true
+		}
+		if isEvidenceFile(mf.Path) {
+			switch m.EvidenceMode {
+			case "none":
+				problems = append(problems, fmt.Sprintf("manifest: evidence_mode none cannot list %q", mf.Path))
+			case "raw", "redacted":
+				if mf.SourcePath == "" {
+					problems = append(problems, fmt.Sprintf("%s: empty source_path", mf.Path))
+				}
+				if mf.SourceSHA256 == "" {
+					problems = append(problems, fmt.Sprintf("%s: empty source_sha256", mf.Path))
+				}
+				if m.EvidenceMode == "raw" && isLowerHex64(mf.SourceSHA256) && mf.SourceSHA256 != mf.SHA256 {
+					problems = append(problems, fmt.Sprintf("%s: raw evidence source_sha256 does not match sha256", mf.Path))
+				}
+			}
 		}
 		if _, ok := seen[mf.Path]; ok {
 			problems = append(problems, fmt.Sprintf("manifest: duplicate path %q", mf.Path))
@@ -185,9 +206,7 @@ func validateManifestFile(mf ManifestFile) []string {
 		problems = append(problems, fmt.Sprintf("%s: rejected: %v", label, err))
 		return problems
 	}
-	isEvidence := strings.HasPrefix(mf.Path, "evidence/") &&
-		strings.TrimPrefix(mf.Path, "evidence/") != "" &&
-		!strings.Contains(strings.TrimPrefix(mf.Path, "evidence/"), "/")
+	isEvidence := isEvidenceFile(mf.Path)
 	if !isRecordFile(mf.Path) && !isEvidence {
 		problems = append(problems, fmt.Sprintf("%s: unexpected bundle path", mf.Path))
 	}
@@ -203,10 +222,18 @@ func validateManifestFile(mf ManifestFile) []string {
 	if isEvidence && mf.Records != 0 {
 		problems = append(problems, fmt.Sprintf("%s: evidence file cannot have a record count", mf.Path))
 	}
-	if isRecordFile(mf.Path) && mf.SourcePath != "" {
-		problems = append(problems, fmt.Sprintf("%s: record file cannot have source_path", mf.Path))
+	if isEvidence && mf.SourceSHA256 != "" && !isLowerHex64(mf.SourceSHA256) {
+		problems = append(problems, fmt.Sprintf("%s: invalid source_sha256", mf.Path))
+	}
+	if isRecordFile(mf.Path) && (mf.SourcePath != "" || mf.SourceSHA256 != "") {
+		problems = append(problems, fmt.Sprintf("%s: record file cannot have source metadata", mf.Path))
 	}
 	return problems
+}
+
+func isEvidenceFile(name string) bool {
+	rel := strings.TrimPrefix(name, "evidence/")
+	return rel != name && rel != "" && !strings.Contains(rel, "/")
 }
 
 func isLowerHex64(s string) bool {

--- a/internal/casebundle/verify_path_test.go
+++ b/internal/casebundle/verify_path_test.go
@@ -251,6 +251,38 @@ func TestVerifyRejectsInvalidManifestStructure(t *testing.T) {
 	}
 }
 
+func TestValidateManifestEvidenceMetadata(t *testing.T) {
+	digestA := strings.Repeat("a", 64)
+	digestB := strings.Repeat("b", 64)
+	base := func(mode string, evidence ManifestFile) Manifest {
+		files := []ManifestFile{{Path: "findings.ndjson"}, {Path: "events.ndjson"}}
+		if evidence.Path != "" {
+			files = append(files, evidence)
+		}
+		return Manifest{
+			SchemaVersion: "0.2.0", CaseID: "case-1", CreatedAt: "2026-06-10T12:00:00Z",
+			Tool: "numbat", ToolVersion: "test", EvidenceMode: mode, Files: files,
+		}
+	}
+	tests := []struct {
+		name string
+		m    Manifest
+		want string
+	}{
+		{"invalid mode", base("masked", ManifestFile{}), `invalid evidence_mode "masked"`},
+		{"none with evidence", base("none", ManifestFile{Path: "evidence/x", SHA256: digestA}), "evidence_mode none"},
+		{"raw missing source hash", base("raw", ManifestFile{Path: "evidence/x", SHA256: digestA, SourcePath: "/tmp/x"}), "empty source_sha256"},
+		{"raw transformed", base("raw", ManifestFile{Path: "evidence/x", SHA256: digestA, SourcePath: "/tmp/x", SourceSHA256: digestB}), "does not match sha256"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := strings.Join(validateManifest(tc.m), "\n"); !strings.Contains(got, tc.want) {
+				t.Fatalf("problems = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestVerifyRejectsUnknownManifestField(t *testing.T) {
 	dir := t.TempDir()
 	raw := `{"schema_version":"0.2.0","case_id":"c","created_at":"2026-06-10T12:00:00Z","tool":"numbat","tool_version":"test","files":[],"surprise":true}`

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -131,15 +131,55 @@ func (s Source) fullProfile() bool { return s.Profile == ProfileFull }
 type Result struct {
 	// Events are the normalized events, in artifact order.
 	Events []model.Event
-	// Diagnostics record non-fatal parse problems (a malformed line, an
-	// unrecognized record shape) so a caller can surface coverage gaps without
-	// the parse aborting.
+	// Diagnostics record a bounded number of non-fatal parse problems (a
+	// malformed line, an unrecognized record shape) so a caller can surface
+	// coverage gaps without the parse aborting or flooding its output.
 	Diagnostics []Diagnostic
+
+	diagnosticCounts      map[string]int
+	diagnosticsSuppressed bool
 }
+
+const (
+	maxDiagnosticsPerArtifact = 20
+	maxRepeatedDiagnostic     = 3
+)
 
 // diag appends a non-fatal diagnostic to the result.
 func (r *Result) diag(path string, line int, msg string) {
-	r.Diagnostics = append(r.Diagnostics, Diagnostic{Path: path, Line: line, Msg: msg})
+	if r.diagnosticCounts == nil {
+		r.diagnosticCounts = make(map[string]int)
+	}
+	key := path + "\x00" + msg
+	if r.diagnosticCounts[key] >= maxRepeatedDiagnostic {
+		r.suppressDiagnostic(path, line)
+		return
+	}
+	realCount := len(r.Diagnostics)
+	if r.diagnosticsSuppressed {
+		realCount--
+	}
+	if realCount >= maxDiagnosticsPerArtifact-1 {
+		r.suppressDiagnostic(path, line)
+		return
+	}
+	r.diagnosticCounts[key]++
+	diagnostic := Diagnostic{Path: path, Line: line, Msg: msg}
+	if !r.diagnosticsSuppressed {
+		r.Diagnostics = append(r.Diagnostics, diagnostic)
+		return
+	}
+	last := len(r.Diagnostics) - 1
+	r.Diagnostics = append(r.Diagnostics, r.Diagnostics[last])
+	r.Diagnostics[last] = diagnostic
+}
+
+func (r *Result) suppressDiagnostic(path string, line int) {
+	if r.diagnosticsSuppressed {
+		return
+	}
+	r.Diagnostics = append(r.Diagnostics, Diagnostic{Path: path, Line: line, Msg: "additional diagnostics suppressed"})
+	r.diagnosticsSuppressed = true
 }
 
 // Diagnostic is a non-fatal problem encountered while parsing an artifact.

--- a/internal/extract/result_test.go
+++ b/internal/extract/result_test.go
@@ -1,0 +1,34 @@
+package extract
+
+import "testing"
+
+func TestResultDiagnosticsAreBounded(t *testing.T) {
+	var result Result
+	for i := 1; i <= maxDiagnosticsPerArtifact*2; i++ {
+		result.diag("artifact.jsonl", i, "malformed record")
+	}
+	result.diag("artifact.jsonl", 100, "unsupported record shape")
+	if len(result.Diagnostics) != maxRepeatedDiagnostic+2 {
+		t.Fatalf("diagnostics = %+v", result.Diagnostics)
+	}
+	if got := result.Diagnostics[len(result.Diagnostics)-2].Msg; got != "unsupported record shape" {
+		t.Fatalf("distinct diagnostic was suppressed: %+v", result.Diagnostics)
+	}
+	last := result.Diagnostics[len(result.Diagnostics)-1]
+	if last.Msg != "additional diagnostics suppressed" {
+		t.Fatalf("last diagnostic = %+v", last)
+	}
+}
+
+func TestResultDistinctDiagnosticsRespectTotalBound(t *testing.T) {
+	var result Result
+	for i := 0; i < maxDiagnosticsPerArtifact*2; i++ {
+		result.diag("artifact.jsonl", i+1, string(rune('a'+i)))
+	}
+	if len(result.Diagnostics) != maxDiagnosticsPerArtifact {
+		t.Fatalf("diagnostics = %d, want %d", len(result.Diagnostics), maxDiagnosticsPerArtifact)
+	}
+	if got := result.Diagnostics[len(result.Diagnostics)-1].Msg; got != "additional diagnostics suppressed" {
+		t.Fatalf("last diagnostic = %q", got)
+	}
+}

--- a/internal/redact/json.go
+++ b/internal/redact/json.go
@@ -1,0 +1,124 @@
+package redact
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+)
+
+var structuredSecretKey = regexp.MustCompile(secretKeyTerm)
+
+var tokenMetricKeys = map[string]struct{}{
+	"audio_tokens":                {},
+	"cache_creation_input_tokens": {},
+	"cache_read_input_tokens":     {},
+	"cache_write_input_tokens":    {},
+	"cached_input_tokens":         {},
+	"cached_tokens":               {},
+	"completion_tokens":           {},
+	"completion_tokens_details":   {},
+	"context_window_tokens":       {},
+	"ephemeral_1h_input_tokens":   {},
+	"ephemeral_5m_input_tokens":   {},
+	"input_token_count":           {},
+	"input_tokens":                {},
+	"input_tokens_details":        {},
+	"last_token_usage":            {},
+	"max_output_tokens":           {},
+	"max_tokens":                  {},
+	"output_token_count":          {},
+	"output_tokens":               {},
+	"output_tokens_details":       {},
+	"prompt_tokens":               {},
+	"prompt_tokens_details":       {},
+	"reasoning_output_tokens":     {},
+	"reasoning_tokens":            {},
+	"time_to_first_token_ms":      {},
+	"token_count":                 {},
+	"token_usage":                 {},
+	"total_token_usage":           {},
+	"total_tokens":                {},
+}
+
+// JSON redacts one JSON value without producing invalid JSON.
+func JSON(raw []byte) ([]byte, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var value any
+	if err := dec.Decode(&value); err != nil {
+		return nil, err
+	}
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err == nil {
+			err = fmt.Errorf("trailing JSON value")
+		}
+		return nil, err
+	}
+	redacted, err := redactJSONValue(value)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(redacted)
+}
+
+func redactJSONValue(value any) (any, error) {
+	switch value := value.(type) {
+	case map[string]any:
+		for key, child := range value {
+			if String(key) != key {
+				return nil, fmt.Errorf("JSON object key contains credential material")
+			}
+			if structuredSecretKey.MatchString(key) && !isTokenMetric(key, child) {
+				value[key] = Mask
+				continue
+			}
+			redacted, err := redactJSONValue(child)
+			if err != nil {
+				return nil, err
+			}
+			value[key] = redacted
+		}
+		return value, nil
+	case []any:
+		for i := range value {
+			redacted, err := redactJSONValue(value[i])
+			if err != nil {
+				return nil, err
+			}
+			value[i] = redacted
+		}
+		return value, nil
+	case string:
+		return String(value), nil
+	default:
+		return value, nil
+	}
+}
+
+func isTokenMetric(key string, value any) bool {
+	key = strings.ToLower(strings.NewReplacer("-", "_", ".", "_").Replace(key))
+	if _, ok := tokenMetricKeys[key]; !ok {
+		return false
+	}
+	return isNumericJSONValue(value)
+}
+
+func isNumericJSONValue(value any) bool {
+	switch value := value.(type) {
+	case json.Number:
+		return true
+	case map[string]any:
+		for _, child := range value {
+			if !isNumericJSONValue(child) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/redact/json_test.go
+++ b/internal/redact/json_test.go
@@ -1,0 +1,65 @@
+package redact
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestJSONPreservesStructureWhileRedacting(t *testing.T) {
+	raw := []byte(`{"total_token_usage":{"input_tokens":42},"time_to_first_token_ms":7,"access_tokens":"opaque-credential","otp_tokens":123456,"password_tokens":123456,"unsafe_token_usage":{"note":"opaque-credential"},"nested":{"api_key":"plain-secret","count":7},"text":"GITHUB_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz0123456789"}`)
+	got, err := JSON(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid(got) {
+		t.Fatalf("redacted JSON is invalid: %s", got)
+	}
+	if strings.Contains(string(got), "plain-secret") || strings.Contains(string(got), "ghp_") {
+		t.Fatalf("redacted JSON leaked a secret: %s", got)
+	}
+	var value map[string]any
+	if err := json.Unmarshal(got, &value); err != nil {
+		t.Fatal(err)
+	}
+	usage, ok := value["total_token_usage"].(map[string]any)
+	if !ok || usage["input_tokens"] != float64(42) || value["time_to_first_token_ms"] != float64(7) {
+		t.Fatalf("token metrics = %#v / %#v", value["total_token_usage"], value["time_to_first_token_ms"])
+	}
+	if value["access_tokens"] != Mask || value["otp_tokens"] != Mask || value["password_tokens"] != Mask || value["unsafe_token_usage"] != Mask {
+		t.Fatalf("credential fields = %#v / %#v / %#v / %#v", value["access_tokens"], value["otp_tokens"], value["password_tokens"], value["unsafe_token_usage"])
+	}
+	nested := value["nested"].(map[string]any)
+	if nested["api_key"] != Mask || nested["count"] != float64(7) {
+		t.Fatalf("nested value = %#v", nested)
+	}
+}
+
+func TestJSONRejectsCredentialInObjectKey(t *testing.T) {
+	raw := []byte(`{"ghp_abcdefghijklmnopqrstuvwxyz0123456789":"value"}`)
+	if _, err := JSON(raw); err == nil || !strings.Contains(err.Error(), "object key") {
+		t.Fatalf("JSON returned err %v, want unsafe-key rejection", err)
+	}
+}
+
+func FuzzJSONProducesValidJSON(f *testing.F) {
+	f.Add([]byte(`{"api_key":"secret","input_tokens":42}`))
+	f.Add([]byte(`{"broken":`))
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		got, err := JSON(raw)
+		if err == nil && !json.Valid(got) {
+			t.Fatalf("JSON returned invalid output: %q", got)
+		}
+	})
+}
+
+func TestJSONRejectsMalformedAndTrailingValues(t *testing.T) {
+	for _, raw := range [][]byte{
+		[]byte(`{"token":`),
+		[]byte(`{"ok":true} {"extra":true}`),
+	} {
+		if _, err := JSON(raw); err == nil {
+			t.Fatalf("JSON(%q) succeeded", raw)
+		}
+	}
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -28,9 +28,11 @@ var tokenPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`-----BEGIN [A-Z ]*PRIVATE KEY-----`),
 }
 
+const secretKeyTerm = `(?i:SECRET|TOKEN|PASSWORD|PASSWD|API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY)`
+
 // secretKey matches a secret-looking assignment key (env var, JSON field,
 // YAML key). Capture group 1 is the key text as written.
-const secretKey = `([A-Za-z0-9_."'-]*(?i:SECRET|TOKEN|PASSWORD|PASSWD|API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY)[A-Za-z0-9_."'-]*)`
+const secretKey = `([A-Za-z0-9_."'-]*` + secretKeyTerm + `[A-Za-z0-9_."'-]*)`
 
 // credentialQueryKeys is the set of URL query-parameter keys that carry
 // credential or signature material — the live-auth params a presigned URL


### PR DESCRIPTION
## Summary
- redact structured JSON and NDJSON without corrupting their syntax
- identify copied evidence as raw or redacted in the manifest
- record source and exported hashes and verify the exported bundle

## Validation
- `go test ./internal/casebundle ./internal/redact ./internal/extract ./cmd/numbat`