### PR TITLE
Mask URL and Authorization credentials

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -246,9 +246,12 @@ numbat writes typed NDJSON streams. Each record carries a `record_type` (`event`
 `endpoint.device_id` for fleet joins.
 `enforcement` is hook-only; `scan_summary` is scan-only.
 
-Event and finding value fields are redacted before emission. Event/timeline
-output keeps a readable, redacted `project_path`; findings and indicators use
-`project_path_hash` / `sample_project_path_hash` for joins. On findings,
+Event and finding value fields are redacted before emission. This includes
+credential query parameters, URL userinfo passwords, Basic/Bearer authorization
+values, secret-like assignments, and self-identifying token formats.
+Event/timeline output keeps a readable, redacted `project_path`; findings and
+indicators use `project_path_hash` / `sample_project_path_hash` for joins. On
+findings,
 `redacted:true` means at least one emitted finding field was masked. File-backed
 evidence refs keep `local_path` so an investigator can reopen the source; live
 hook and OTLP refs may omit it because there is no source file.

--- a/internal/output/indicators_extract.go
+++ b/internal/output/indicators_extract.go
@@ -46,10 +46,11 @@ const maxExtractedIndicatorsPerField = 256
 // pipeline is captured without trailing pipe/redirect noise.
 var urlInText = regexp.MustCompile(`(?i:https?)://[^\s"'<>` + "`" + `|;)\\]+`)
 
-// uriAuthorityInText fences non-HTTP URI authorities from standalone miners.
-// Credentials and usernames inside a DSN are evidence, not independent IOCs.
+// uriAuthorityInText locates generic URI authorities. Their hosts are classified
+// directly; the full authority is then fenced from standalone miners so userinfo
+// cannot be reclassified as an indicator.
 var uriAuthorityInText = regexp.MustCompile(
-	`(?i:[a-z][a-z0-9+.-]*)://[A-Za-z0-9._~!$'*+%:@=-]+`,
+	`(?i:[a-z][a-z0-9+.-]*)://[A-Za-z0-9._~!$&'()*+,;=:%@\[\]-]+`,
 )
 
 // emailInText matches a conservative email address shape. The local part and
@@ -135,6 +136,20 @@ func extractIndicators(s string, markdown bool) ([]typedIndicator, bool) {
 		add(htyp, hval)
 	}
 
+	uriMatches := uriAuthorityInText.FindAllStringIndex(s, maxExtractedIndicatorsPerField+1)
+	if len(uriMatches) > maxExtractedIndicatorsPerField {
+		truncated = true
+	}
+	for _, loc := range uriMatches {
+		host, ok := nonHTTPURIHost(s[loc[0]:loc[1]])
+		if !ok {
+			continue
+		}
+		if typ, val := classifyHost(host); typ != "" {
+			add(typ, val)
+		}
+	}
+
 	// All non-URL miners run over a URL-blanked view of the text: bytes inside a
 	// URL authority (notably userinfo, user:pass@host) have already been decided
 	// by URL canonicalization and must never be reclassified as a standalone indicator.
@@ -177,6 +192,32 @@ func extractIndicators(s string, markdown bool) ([]typedIndicator, bool) {
 		}
 	}
 	return out, truncated
+}
+
+func nonHTTPURIHost(raw string) (string, bool) {
+	schemeEnd := strings.Index(raw, "://")
+	if schemeEnd <= 0 {
+		return "", false
+	}
+	scheme := raw[:schemeEnd]
+	if strings.EqualFold(scheme, "http") || strings.EqualFold(scheme, "https") {
+		return "", false
+	}
+	authority := raw[schemeEnd+3:]
+	if at := strings.LastIndexByte(authority, '@'); at >= 0 {
+		authority = authority[at+1:]
+	}
+	if strings.HasPrefix(authority, "[") {
+		end := strings.IndexByte(authority, ']')
+		if end <= 1 {
+			return "", false
+		}
+		return authority[1:end], true
+	}
+	if colon := strings.LastIndexByte(authority, ':'); colon >= 0 {
+		authority = authority[:colon]
+	}
+	return authority, authority != ""
 }
 
 // trimTrailingMarkdownEmphasis removes an exact closing bold marker from a

--- a/internal/output/indicators_extract.go
+++ b/internal/output/indicators_extract.go
@@ -46,6 +46,12 @@ const maxExtractedIndicatorsPerField = 256
 // pipeline is captured without trailing pipe/redirect noise.
 var urlInText = regexp.MustCompile(`(?i:https?)://[^\s"'<>` + "`" + `|;)\\]+`)
 
+// uriAuthorityInText fences non-HTTP URI authorities from standalone miners.
+// Credentials and usernames inside a DSN are evidence, not independent IOCs.
+var uriAuthorityInText = regexp.MustCompile(
+	`(?i:[a-z][a-z0-9+.-]*)://[A-Za-z0-9._~!$'*+%:@=-]+`,
+)
+
 // emailInText matches a conservative email address shape. The local part and
 // domain are restricted to the characters that appear in real addresses; the TLD
 // must be at least two letters so a bare `a@b` or a version string is not caught.
@@ -423,11 +429,15 @@ func trimHostRootDot(host string) string {
 	return strings.TrimRight(host, ".")
 }
 
-// blankURLs returns s with every http(s) URL span replaced by spaces of equal
-// length. Offsets are preserved so non-URL spans are unchanged; used to fence the
-// standalone IPv4/hash/email miners off a URL's authority/userinfo (see extractIndicators).
+// blankURLs replaces HTTP URLs and other URI authorities with equal-length
+// spaces so their userinfo cannot be reclassified as standalone indicators.
 func blankURLs(s string) string {
-	locs := urlInText.FindAllStringIndex(s, -1)
+	s = blankMatches(s, urlInText)
+	return blankMatches(s, uriAuthorityInText)
+}
+
+func blankMatches(s string, re *regexp.Regexp) string {
+	locs := re.FindAllStringIndex(s, -1)
 	if len(locs) == 0 {
 		return s
 	}

--- a/internal/output/indicators_extract.go
+++ b/internal/output/indicators_extract.go
@@ -46,12 +46,10 @@ const maxExtractedIndicatorsPerField = 256
 // pipeline is captured without trailing pipe/redirect noise.
 var urlInText = regexp.MustCompile(`(?i:https?)://[^\s"'<>` + "`" + `|;)\\]+`)
 
-// uriAuthorityInText locates generic URI authorities. Their hosts are classified
-// directly; the full authority is then fenced from standalone miners so userinfo
-// cannot be reclassified as an indicator.
-var uriAuthorityInText = regexp.MustCompile(
-	`(?i:[a-z][a-z0-9+.-]*)://[A-Za-z0-9._~!$&'()*+,;=:%@\[\]-]+`,
-)
+// uriSchemeInText starts generic URI authority scanning. A small walker below
+// finds the actual host boundary because userinfo may contain URI punctuation
+// that also separates adjacent prose.
+var uriSchemeInText = regexp.MustCompile(`(?i:[a-z][a-z0-9+.-]*)://`)
 
 // emailInText matches a conservative email address shape. The local part and
 // domain are restricted to the characters that appear in real addresses; the TLD
@@ -136,16 +134,15 @@ func extractIndicators(s string, markdown bool) ([]typedIndicator, bool) {
 		add(htyp, hval)
 	}
 
-	uriMatches := uriAuthorityInText.FindAllStringIndex(s, maxExtractedIndicatorsPerField+1)
+	uriMatches := uriAuthorities(s, maxExtractedIndicatorsPerField+1)
 	if len(uriMatches) > maxExtractedIndicatorsPerField {
 		truncated = true
 	}
 	for _, loc := range uriMatches {
-		host, ok := nonHTTPURIHost(s[loc[0]:loc[1]])
-		if !ok {
+		if loc.host == "" {
 			continue
 		}
-		if typ, val := classifyHost(host); typ != "" {
+		if typ, val := classifyHost(loc.host); typ != "" {
 			add(typ, val)
 		}
 	}
@@ -194,30 +191,87 @@ func extractIndicators(s string, markdown bool) ([]typedIndicator, bool) {
 	return out, truncated
 }
 
-func nonHTTPURIHost(raw string) (string, bool) {
-	schemeEnd := strings.Index(raw, "://")
-	if schemeEnd <= 0 {
-		return "", false
-	}
-	scheme := raw[:schemeEnd]
-	if strings.EqualFold(scheme, "http") || strings.EqualFold(scheme, "https") {
-		return "", false
-	}
-	authority := raw[schemeEnd+3:]
-	if at := strings.LastIndexByte(authority, '@'); at >= 0 {
-		authority = authority[at+1:]
-	}
-	if strings.HasPrefix(authority, "[") {
-		end := strings.IndexByte(authority, ']')
-		if end <= 1 {
-			return "", false
+type uriAuthority struct {
+	start int
+	end   int
+	host  string
+}
+
+func uriAuthorities(s string, limit int) []uriAuthority {
+	schemes := uriSchemeInText.FindAllStringIndex(s, limit)
+	out := make([]uriAuthority, 0, len(schemes))
+	for _, loc := range schemes {
+		end := loc[1]
+		for end < len(s) && !uriHardTerminator(s[end]) {
+			end++
 		}
-		return authority[1:end], true
+		host, authorityEnd, ok := uriHost(s[loc[1]:end])
+		if !ok {
+			continue
+		}
+		scheme := s[loc[0] : loc[1]-3]
+		if strings.EqualFold(scheme, "http") || strings.EqualFold(scheme, "https") {
+			host = ""
+		}
+		out = append(out, uriAuthority{start: loc[0], end: loc[1] + authorityEnd, host: host})
 	}
-	if colon := strings.LastIndexByte(authority, ':'); colon >= 0 {
-		authority = authority[:colon]
+	return out
+}
+
+func uriHost(authority string) (string, int, bool) {
+	if sep := strings.IndexAny(authority, ",;"); sep >= 0 {
+		if host, ok := parsedURIHost(authority[:sep]); ok {
+			return host, sep, true
+		}
 	}
-	return authority, authority != ""
+	for search := 0; search < len(authority); {
+		rel := strings.IndexByte(authority[search:], '@')
+		if rel < 0 {
+			break
+		}
+		at := search + rel
+		end := at + 1
+		for end < len(authority) && !uriHostSeparator(authority[end]) {
+			end++
+		}
+		if host, ok := parsedURIHost(authority[at+1 : end]); ok {
+			return host, end, true
+		}
+		search = at + 1
+	}
+	end := 0
+	for end < len(authority) && !uriHostSeparator(authority[end]) {
+		end++
+	}
+	host, ok := parsedURIHost(authority[:end])
+	return host, end, ok
+}
+
+func uriHostSeparator(b byte) bool {
+	switch b {
+	case ',', ';', '&', '\'', '(', ')', '*', '+', '=':
+		return true
+	}
+	return false
+}
+
+func uriHardTerminator(b byte) bool {
+	switch b {
+	case '/', '?', '#', '"', '`', '<', '>', '\\', '{', '}', '|', '^':
+		return true
+	}
+	return b <= ' ' || b >= 0x7f
+}
+
+func parsedURIHost(hostport string) (string, bool) {
+	if hostport == "" || strings.ContainsRune(hostport, '@') {
+		return "", false
+	}
+	u, err := url.Parse("scheme://" + hostport)
+	if err != nil || u.User != nil || u.Host != hostport || u.Hostname() == "" {
+		return "", false
+	}
+	return u.Hostname(), true
 }
 
 // trimTrailingMarkdownEmphasis removes an exact closing bold marker from a
@@ -474,7 +528,21 @@ func trimHostRootDot(host string) string {
 // spaces so their userinfo cannot be reclassified as standalone indicators.
 func blankURLs(s string) string {
 	s = blankMatches(s, urlInText)
-	return blankMatches(s, uriAuthorityInText)
+	return blankURIAuthorities(s)
+}
+
+func blankURIAuthorities(s string) string {
+	matches := uriAuthorities(s, -1)
+	if len(matches) == 0 {
+		return s
+	}
+	b := []byte(s)
+	for _, match := range matches {
+		for i := match.start; i < match.end; i++ {
+			b[i] = ' '
+		}
+	}
+	return string(b)
 }
 
 func blankMatches(s string, re *regexp.Regexp) string {

--- a/internal/output/indicators_extract.go
+++ b/internal/output/indicators_extract.go
@@ -219,7 +219,7 @@ func uriAuthorities(s string, limit int) []uriAuthority {
 }
 
 func uriHost(authority string) (string, int, bool) {
-	if sep := strings.IndexAny(authority, ",;"); sep >= 0 {
+	if sep := strings.IndexAny(authority, ",;&"); sep >= 0 {
 		if host, ok := parsedURIHost(authority[:sep]); ok {
 			return host, sep, true
 		}

--- a/internal/output/indicators_test.go
+++ b/internal/output/indicators_test.go
@@ -407,6 +407,24 @@ func TestIndicatorsDSNUserinfoNotMined(t *testing.T) {
 	}
 }
 
+func TestIndicatorsRetainDSNHostBeforeDelimitedProse(t *testing.T) {
+	events := []model.Event{
+		{EventType: model.EventCommandExec, Command: "connect postgres://user:secret@db.example:5432;ops@example.com", EventID: "e1"},
+		{EventType: model.EventCommandExec, Command: "connect redis://user:secret@cache.example:6379,admin@example.com", EventID: "e2"},
+	}
+	inds := Indicators(events)
+	for _, host := range []string{"db.example", "cache.example"} {
+		if findInd(inds, IndicatorDomain, host) == nil {
+			t.Errorf("indicator %q was lost: %+v", host, inds)
+		}
+	}
+	for _, email := range []string{"ops@example.com", "admin@example.com"} {
+		if findInd(inds, IndicatorEmail, email) == nil {
+			t.Errorf("indicator %q was lost: %+v", email, inds)
+		}
+	}
+}
+
 // An uppercase/mixed-case URL scheme must be recognized as a URL so its userinfo
 // is fenced off the standalone miners exactly like a lowercase scheme. Without a
 // case-insensitive scheme match, HTTPS://8.8.8.8@evil.example/x would skip both

--- a/internal/output/indicators_test.go
+++ b/internal/output/indicators_test.go
@@ -411,14 +411,15 @@ func TestIndicatorsRetainDSNHostBeforeDelimitedProse(t *testing.T) {
 	events := []model.Event{
 		{EventType: model.EventCommandExec, Command: "connect postgres://user:secret@db.example:5432;ops@example.com", EventID: "e1"},
 		{EventType: model.EventCommandExec, Command: "connect redis://user:secret@cache.example:6379,admin@example.com", EventID: "e2"},
+		{EventType: model.EventCommandExec, Command: "connect amqp://user:secret@broker.example:5672&owner@example.com", EventID: "e3"},
 	}
 	inds := Indicators(events)
-	for _, host := range []string{"db.example", "cache.example"} {
+	for _, host := range []string{"db.example", "cache.example", "broker.example"} {
 		if findInd(inds, IndicatorDomain, host) == nil {
 			t.Errorf("indicator %q was lost: %+v", host, inds)
 		}
 	}
-	for _, email := range []string{"ops@example.com", "admin@example.com"} {
+	for _, email := range []string{"ops@example.com", "admin@example.com", "owner@example.com"} {
 		if findInd(inds, IndicatorEmail, email) == nil {
 			t.Errorf("indicator %q was lost: %+v", email, inds)
 		}

--- a/internal/output/indicators_test.go
+++ b/internal/output/indicators_test.go
@@ -370,6 +370,30 @@ func TestIndicatorsUserinfoNotMinedAsIPOrHash(t *testing.T) {
 	}
 }
 
+func TestIndicatorsDSNUserinfoNotMined(t *testing.T) {
+	hash := "0123456789abcdef0123456789abcdef"
+	events := []model.Event{
+		{EventType: model.EventCommandExec, Command: "connect postgres://8.8.8.8:secret@db.example/app", EventID: "e1"},
+		{EventType: model.EventCommandExec, Command: "connect redis://" + hash + ":secret@cache.example/0", EventID: "e2"},
+		{EventType: model.EventCommandExec, Command: "connect postgres://user:secret@db.example/app then https://evil.example/x", EventID: "e3"},
+	}
+	inds := Indicators(events)
+	if ind := findInd(inds, IndicatorIPv4, "8.8.8.8"); ind != nil {
+		t.Errorf("DSN username must not be mined as ipv4: %+v", ind)
+	}
+	if ind := findInd(inds, IndicatorMD5, hash); ind != nil {
+		t.Errorf("DSN username must not be mined as md5: %+v", ind)
+	}
+	for _, ind := range inds {
+		if ind.Type == IndicatorEmail {
+			t.Errorf("redacted DSN userinfo must not become an email: %+v", ind)
+		}
+	}
+	if findInd(inds, IndicatorDomain, "evil.example") == nil {
+		t.Errorf("indicator outside DSN was lost: %+v", inds)
+	}
+}
+
 // An uppercase/mixed-case URL scheme must be recognized as a URL so its userinfo
 // is fenced off the standalone miners exactly like a lowercase scheme. Without a
 // case-insensitive scheme match, HTTPS://8.8.8.8@evil.example/x would skip both

--- a/internal/output/indicators_test.go
+++ b/internal/output/indicators_test.go
@@ -373,9 +373,11 @@ func TestIndicatorsUserinfoNotMinedAsIPOrHash(t *testing.T) {
 func TestIndicatorsDSNUserinfoNotMined(t *testing.T) {
 	hash := "0123456789abcdef0123456789abcdef"
 	events := []model.Event{
-		{EventType: model.EventCommandExec, Command: "connect postgres://8.8.8.8:secret@db.example/app", EventID: "e1"},
-		{EventType: model.EventCommandExec, Command: "connect redis://" + hash + ":secret@cache.example/0", EventID: "e2"},
+		{EventType: model.EventCommandExec, Command: "connect postgres://8.8.8.8:secret@db.example:5432/app", EventID: "e1"},
+		{EventType: model.EventCommandExec, Command: "connect redis://" + hash + ":secret@cache.example:6379/0", EventID: "e2"},
 		{EventType: model.EventCommandExec, Command: "connect postgres://user:secret@db.example/app then https://evil.example/x", EventID: "e3"},
+		{EventType: model.EventCommandExec, Command: "connect postgres://user:p!$&'()*+,;=ss@9.9.9.9/db", EventID: "e4"},
+		{EventType: model.EventCommandExec, Command: "connect redis://user:secret@[2001:4860:4860::8888]:6379/0", EventID: "e5"},
 	}
 	inds := Indicators(events)
 	if ind := findInd(inds, IndicatorIPv4, "8.8.8.8"); ind != nil {
@@ -391,6 +393,17 @@ func TestIndicatorsDSNUserinfoNotMined(t *testing.T) {
 	}
 	if findInd(inds, IndicatorDomain, "evil.example") == nil {
 		t.Errorf("indicator outside DSN was lost: %+v", inds)
+	}
+	for _, host := range []string{"db.example", "cache.example"} {
+		if findInd(inds, IndicatorDomain, host) == nil {
+			t.Errorf("DSN host %q was lost: %+v", host, inds)
+		}
+	}
+	if findInd(inds, IndicatorIPv4, "9.9.9.9") == nil {
+		t.Errorf("DSN IPv4 host was lost: %+v", inds)
+	}
+	if findInd(inds, IndicatorIPv6, "2001:4860:4860::8888") == nil {
+		t.Errorf("DSN IPv6 host was lost: %+v", inds)
 	}
 }
 

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -6,6 +6,7 @@
 package redact
 
 import (
+	"net/url"
 	"regexp"
 	"strings"
 )
@@ -113,16 +114,12 @@ func maskURLUserinfo(s string) string {
 			continue
 		}
 		authorityEnd := uriAuthorityEnd(s, authorityStart)
-		at := strings.LastIndexByte(s[authorityStart:authorityEnd], '@')
-		if at < 0 {
+		passwordStart, passwordEnd, ok := uriPasswordSpan(s[authorityStart:authorityEnd])
+		if !ok {
 			continue
 		}
-		colon := strings.IndexByte(s[authorityStart:authorityStart+at], ':')
-		if colon < 0 {
-			continue
-		}
-		credentialStart := authorityStart + colon + 1
-		credentialEnd := authorityStart + at
+		credentialStart := authorityStart + passwordStart
+		credentialEnd := authorityStart + passwordEnd
 		if credentialStart >= credentialEnd {
 			continue
 		}
@@ -135,6 +132,65 @@ func maskURLUserinfo(s string) string {
 	}
 	b.WriteString(s[last:])
 	return b.String()
+}
+
+// uriPasswordSpan finds user:password only when an @ is followed by a valid
+// host. Choosing the first such @ preserves @ inside passwords without letting
+// a later email address steal the host from an earlier DSN.
+func uriPasswordSpan(authority string) (int, int, bool) {
+	for search := 0; search < len(authority); {
+		rel := strings.IndexByte(authority[search:], '@')
+		if rel < 0 {
+			return 0, 0, false
+		}
+		at := search + rel
+		hostEnd := at + 1
+		for hostEnd < len(authority) && !uriHostTerminator(authority[hostEnd]) {
+			hostEnd++
+		}
+		if validURIHost(authority[at+1 : hostEnd]) {
+			colon := strings.IndexByte(authority[:at], ':')
+			if colon < 0 || completeHostPortBeforeSeparator(authority[:at]) {
+				return 0, 0, false
+			}
+			return colon + 1, at, colon+1 < at
+		}
+		search = at + 1
+	}
+	return 0, 0, false
+}
+
+func uriHostTerminator(b byte) bool {
+	switch b {
+	case ',', ';', '&', '\'', '(', ')', '*', '+', '=':
+		return true
+	}
+	return uriAuthorityTerminator(b)
+}
+
+func validURIHost(hostport string) bool {
+	if hostport == "" || strings.ContainsRune(hostport, '@') {
+		return false
+	}
+	u, err := url.Parse("scheme://" + hostport)
+	return err == nil && u.User == nil && u.Host == hostport && u.Hostname() != ""
+}
+
+// completeHostPortBeforeSeparator recognizes "host:port;...@..." prose. The
+// dotted/IP host requirement avoids treating an ordinary user:digits password
+// as a completed network authority.
+func completeHostPortBeforeSeparator(beforeAt string) bool {
+	sep := strings.IndexAny(beforeAt, ",;")
+	if sep < 0 {
+		return false
+	}
+	prefix := beforeAt[:sep]
+	u, err := url.Parse("scheme://" + prefix)
+	if err != nil || u.User != nil || u.Host != prefix || u.Hostname() == "" || u.Port() == "" {
+		return false
+	}
+	host := u.Hostname()
+	return strings.ContainsRune(host, '.') || strings.ContainsRune(host, ':')
 }
 
 func uriAuthorityEnd(s string, start int) int {

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -30,6 +30,16 @@ var tokenPatterns = []*regexp.Regexp{
 
 const secretKeyTerm = `(?i:SECRET|TOKEN|PASSWORD|PASSWD|API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY)`
 
+var (
+	uriSchemePattern               = regexp.MustCompile(`[A-Za-z][A-Za-z0-9+.-]*://`)
+	authorizationCredentialPattern = regexp.MustCompile(
+		`(?i)(^|[^A-Za-z0-9_-])((?:proxy-)?authorization["']?\]?[ \t]*[:=][ \t]*["']?(?:basic|bearer)[ \t]+)([A-Za-z0-9._~+/\-]+=*)`,
+	)
+)
+
+// urlPasswordMask is valid URL userinfo and cannot be mined as an email local part.
+const urlPasswordMask = "***"
+
 // secretKey matches a secret-looking assignment key (env var, JSON field,
 // YAML key). Capture group 1 is the key text as written.
 const secretKey = `([A-Za-z0-9_."'-]*` + secretKeyTerm + `[A-Za-z0-9_."'-]*)`
@@ -72,6 +82,8 @@ const maxCredentialQueryKeyLen = len("x-amz-security-token")
 // patterns are limited to non-URL spans to avoid masking benign query keys such
 // as id_token.
 func String(s string) string {
+	s = maskURLUserinfoPasswords(s)
+	s = maskAuthorizationCredentials(s)
 	s = maskCredentialValues(s)
 	var b strings.Builder
 	last := 0
@@ -86,6 +98,58 @@ func String(s string) string {
 		out = p.ReplaceAllString(out, Mask)
 	}
 	return out
+}
+
+func maskAuthorizationCredentials(s string) string {
+	return authorizationCredentialPattern.ReplaceAllString(s, "${1}${2}"+Mask)
+}
+
+func maskURLUserinfoPasswords(s string) string {
+	var b strings.Builder
+	last := 0
+	for _, loc := range uriSchemePattern.FindAllStringIndex(s, -1) {
+		authorityStart := loc[1]
+		if authorityStart < last {
+			continue
+		}
+		authorityEnd := uriAuthorityEnd(s, authorityStart)
+		at := strings.LastIndexByte(s[authorityStart:authorityEnd], '@')
+		if at < 0 {
+			continue
+		}
+		colon := strings.IndexByte(s[authorityStart:authorityStart+at], ':')
+		if colon < 0 {
+			continue
+		}
+		passwordStart := authorityStart + colon + 1
+		passwordEnd := authorityStart + at
+		if passwordStart >= passwordEnd {
+			continue
+		}
+		b.WriteString(s[last:passwordStart])
+		b.WriteString(urlPasswordMask)
+		last = passwordEnd
+	}
+	if last == 0 {
+		return s
+	}
+	b.WriteString(s[last:])
+	return b.String()
+}
+
+func uriAuthorityEnd(s string, start int) int {
+	for start < len(s) && !uriAuthorityTerminator(s[start]) {
+		start++
+	}
+	return start
+}
+
+func uriAuthorityTerminator(b byte) bool {
+	switch b {
+	case '/', '?', '#', '"', '\'', '`', '<', '>', '\\', '{', '}', '[', ']', '|', '^', ',', ';', '&', '(', ')':
+		return true
+	}
+	return b <= ' ' || b >= 0x7f
 }
 
 // urlPattern matches an http(s) URL substring inside arbitrary text. It is used

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -37,8 +37,8 @@ var (
 	)
 )
 
-// urlPasswordMask is valid URL userinfo and cannot be mined as an email local part.
-const urlPasswordMask = "***"
+// urlUserinfoMask is valid URL userinfo and cannot be mined as an email local part.
+const urlUserinfoMask = "***"
 
 // secretKey matches a secret-looking assignment key (env var, JSON field,
 // YAML key). Capture group 1 is the key text as written.
@@ -82,7 +82,7 @@ const maxCredentialQueryKeyLen = len("x-amz-security-token")
 // patterns are limited to non-URL spans to avoid masking benign query keys such
 // as id_token.
 func String(s string) string {
-	s = maskURLUserinfoPasswords(s)
+	s = maskURLUserinfo(s)
 	s = maskAuthorizationCredentials(s)
 	s = maskCredentialValues(s)
 	var b strings.Builder
@@ -104,7 +104,7 @@ func maskAuthorizationCredentials(s string) string {
 	return authorizationCredentialPattern.ReplaceAllString(s, "${1}${2}"+Mask)
 }
 
-func maskURLUserinfoPasswords(s string) string {
+func maskURLUserinfo(s string) string {
 	var b strings.Builder
 	last := 0
 	for _, loc := range uriSchemePattern.FindAllStringIndex(s, -1) {
@@ -121,14 +121,14 @@ func maskURLUserinfoPasswords(s string) string {
 		if colon < 0 {
 			continue
 		}
-		passwordStart := authorityStart + colon + 1
-		passwordEnd := authorityStart + at
-		if passwordStart >= passwordEnd {
+		credentialStart := authorityStart + colon + 1
+		credentialEnd := authorityStart + at
+		if credentialStart >= credentialEnd {
 			continue
 		}
-		b.WriteString(s[last:passwordStart])
-		b.WriteString(urlPasswordMask)
-		last = passwordEnd
+		b.WriteString(s[last:credentialStart])
+		b.WriteString(urlUserinfoMask)
+		last = credentialEnd
 	}
 	if last == 0 {
 		return s

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -146,7 +146,7 @@ func uriAuthorityEnd(s string, start int) int {
 
 func uriAuthorityTerminator(b byte) bool {
 	switch b {
-	case '/', '?', '#', '"', '\'', '`', '<', '>', '\\', '{', '}', '[', ']', '|', '^', ',', ';', '&', '(', ')':
+	case '/', '?', '#', '"', '`', '<', '>', '\\', '{', '}', '|', '^':
 		return true
 	}
 	return b <= ' ' || b >= 0x7f

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -180,7 +180,7 @@ func validURIHost(hostport string) bool {
 // dotted/IP host requirement avoids treating an ordinary user:digits password
 // as a completed network authority.
 func completeHostPortBeforeSeparator(beforeAt string) bool {
-	sep := strings.IndexAny(beforeAt, ",;")
+	sep := strings.IndexAny(beforeAt, ",;&")
 	if sep < 0 {
 		return false
 	}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,6 +1,7 @@
 package redact
 
 import (
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -92,13 +93,86 @@ func TestStringLeavesBenignText(t *testing.T) {
 func TestStringKnownFalseNegatives(t *testing.T) {
 	cases := []string{
 		"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", // bare AWS secret access key, no key= prefix
-		"postgres://user:p4ssw0rd@host:5432/db",    // DB-URL embedded password
-		"Authorization: Bearer abcdef123456",       // bearer token without a secret-looking key
 	}
 	for _, c := range cases {
 		if got := String(c); !strings.Contains(got, c) {
 			t.Fatalf("behavior changed (now masked) for known false negative %q -> %q", c, got)
 		}
+	}
+}
+
+func TestStringMasksURLUserinfoPasswords(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"postgres://user:p4ssw0rd@host:5432/db", "postgres://user:***@host:5432/db"},
+		{"redis://user:pa:ss@cache.example/0", "redis://user:***@cache.example/0"},
+		{"amqp://user:p@ss@broker.example/vhost", "amqp://user:***@broker.example/vhost"},
+		{"https://user:secret@[2001:db8::1]/", "https://user:***@[2001:db8::1]/"},
+		{
+			"postgres://a:first@one.example/db redis://b:second@two.example/0",
+			"postgres://a:***@one.example/db redis://b:***@two.example/0",
+		},
+	}
+	for _, tt := range tests {
+		if got := String(tt.in); got != tt.want {
+			t.Errorf("String(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+		if got := String(tt.want); got != tt.want {
+			t.Errorf("String is not idempotent: %q -> %q", tt.want, got)
+		}
+	}
+}
+
+func TestStringURLUserinfoMaskRemainsParseable(t *testing.T) {
+	got := String("postgres://user:secret@db.example/app")
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", got, err)
+	}
+	password, ok := u.User.Password()
+	if !ok || password != urlPasswordMask {
+		t.Fatalf("parsed password = %q, %v", password, ok)
+	}
+}
+
+func TestStringDoesNotInventURLUserinfo(t *testing.T) {
+	tests := []string{
+		"https://api.example:8443;user=ops@example.com",
+		"api.example,https://api.example:8443,ops@example.com",
+		"https://api.example:8443 then ops@example.com",
+		"https://[2001:db8::1]:8443/",
+	}
+	for _, in := range tests {
+		if got := String(in); got != in {
+			t.Errorf("String(%q) = %q", in, got)
+		}
+	}
+}
+
+func TestStringMasksAuthorizationCredentials(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"Authorization: Bearer abcdef123456", "Authorization: Bearer " + Mask},
+		{"Authorization: Bearer test", "Authorization: Bearer " + Mask},
+		{"authorization=basic dXNlcjpwYXNz", "authorization=basic " + Mask},
+		{`{"Authorization":"Bearer abcdef123456"}`, `{"Authorization":"Bearer ` + Mask + `"}`},
+		{`headers["Authorization"] = "Bearer abcdef123456"`, `headers["Authorization"] = "Bearer ` + Mask + `"`},
+		{"Proxy-Authorization: Basic dXNlcjpwYXNz", "Proxy-Authorization: Basic " + Mask},
+	}
+	for _, tt := range tests {
+		if got := String(tt.in); got != tt.want {
+			t.Errorf("String(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+		if got := String(tt.want); got != tt.want {
+			t.Errorf("String is not idempotent: %q -> %q", tt.want, got)
+		}
+	}
+	if got := String("Bearer abcdef123456"); got != "Bearer abcdef123456" {
+		t.Errorf("unanchored bearer text changed: %q", got)
 	}
 }
 
@@ -1303,6 +1377,14 @@ func FuzzString(f *testing.F) {
 		got := String(in) // must not panic
 		if strings.Contains(got, secret) {
 			t.Fatalf("secret survived redaction: %q -> %q", in, got)
+		}
+		for _, positioned := range []string{
+			prefix + " postgres://user:" + secret + "@db.example/app " + suffix,
+			prefix + "\nAuthorization: Bearer " + secret + "\n" + suffix,
+		} {
+			if got := String(positioned); strings.Contains(got, secret) {
+				t.Fatalf("positioned secret survived redaction: %q -> %q", positioned, got)
+			}
 		}
 		_ = String(prefix + suffix) // exercise arbitrary non-secret text for panics
 	})

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -112,6 +112,7 @@ func TestStringMasksURLUserinfo(t *testing.T) {
 		{"postgres://user:p!$&'()*+,;=ss@db.example/app", "postgres://user:***@db.example/app"},
 		{"postgres://user:secret@db.example:5432;ops@example.com", "postgres://user:***@db.example:5432;ops@example.com"},
 		{"redis://user:secret@cache.example:6379,admin@example.com", "redis://user:***@cache.example:6379,admin@example.com"},
+		{"postgres://user:secret@db.example:5432&owner@example.com", "postgres://user:***@db.example:5432&owner@example.com"},
 		{"https://user:secret@[2001:db8::1]/", "https://user:***@[2001:db8::1]/"},
 		{
 			"postgres://a:first@one.example/db redis://b:second@two.example/0",
@@ -143,6 +144,7 @@ func TestStringPreservesURLWithoutUserinfo(t *testing.T) {
 	tests := []string{
 		"https://api.example:8443;user=ops@example.com",
 		"api.example,https://api.example:8443,ops@example.com",
+		"https://api.example:8443&user=ops@example.com",
 		"https://api.example:8443 then ops@example.com",
 		"https://[2001:db8::1]:8443/",
 	}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -131,9 +131,8 @@ func TestStringURLUserinfoMaskRemainsParseable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("url.Parse(%q): %v", got, err)
 	}
-	password, ok := u.User.Password()
-	if !ok || password != urlPasswordMask {
-		t.Fatalf("parsed password = %q, %v", password, ok)
+	if u.User == nil || u.Host != "db.example" {
+		t.Fatalf("parsed URL lost userinfo or host: %#v", u)
 	}
 }
 

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -109,7 +109,16 @@ func TestStringMasksURLUserinfo(t *testing.T) {
 		{"postgres://user:p4ssw0rd@host:5432/db", "postgres://user:***@host:5432/db"},
 		{"redis://user:pa:ss@cache.example/0", "redis://user:***@cache.example/0"},
 		{"amqp://user:p@ss@broker.example/vhost", "amqp://user:***@broker.example/vhost"},
+		{"postgres://user:p!$&'()*+,;=ss@db.example/app", "postgres://user:***@db.example/app"},
 		{"https://user:secret@[2001:db8::1]/", "https://user:***@[2001:db8::1]/"},
+		{
+			"https://api.example:8443;user=ops@example.com",
+			"https://api.example:***@example.com",
+		},
+		{
+			"api.example,https://api.example:8443,ops@example.com",
+			"api.example,https://api.example:***@example.com",
+		},
 		{
 			"postgres://a:first@one.example/db redis://b:second@two.example/0",
 			"postgres://a:***@one.example/db redis://b:***@two.example/0",
@@ -136,10 +145,8 @@ func TestStringURLUserinfoMaskRemainsParseable(t *testing.T) {
 	}
 }
 
-func TestStringDoesNotInventURLUserinfo(t *testing.T) {
+func TestStringPreservesURLWithoutUserinfo(t *testing.T) {
 	tests := []string{
-		"https://api.example:8443;user=ops@example.com",
-		"api.example,https://api.example:8443,ops@example.com",
 		"https://api.example:8443 then ops@example.com",
 		"https://[2001:db8::1]:8443/",
 	}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -110,15 +110,9 @@ func TestStringMasksURLUserinfo(t *testing.T) {
 		{"redis://user:pa:ss@cache.example/0", "redis://user:***@cache.example/0"},
 		{"amqp://user:p@ss@broker.example/vhost", "amqp://user:***@broker.example/vhost"},
 		{"postgres://user:p!$&'()*+,;=ss@db.example/app", "postgres://user:***@db.example/app"},
+		{"postgres://user:secret@db.example:5432;ops@example.com", "postgres://user:***@db.example:5432;ops@example.com"},
+		{"redis://user:secret@cache.example:6379,admin@example.com", "redis://user:***@cache.example:6379,admin@example.com"},
 		{"https://user:secret@[2001:db8::1]/", "https://user:***@[2001:db8::1]/"},
-		{
-			"https://api.example:8443;user=ops@example.com",
-			"https://api.example:***@example.com",
-		},
-		{
-			"api.example,https://api.example:8443,ops@example.com",
-			"api.example,https://api.example:***@example.com",
-		},
 		{
 			"postgres://a:first@one.example/db redis://b:second@two.example/0",
 			"postgres://a:***@one.example/db redis://b:***@two.example/0",
@@ -147,6 +141,8 @@ func TestStringURLUserinfoMaskRemainsParseable(t *testing.T) {
 
 func TestStringPreservesURLWithoutUserinfo(t *testing.T) {
 	tests := []string{
+		"https://api.example:8443;user=ops@example.com",
+		"api.example,https://api.example:8443,ops@example.com",
 		"https://api.example:8443 then ops@example.com",
 		"https://[2001:db8::1]:8443/",
 	}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -101,7 +101,7 @@ func TestStringKnownFalseNegatives(t *testing.T) {
 	}
 }
 
-func TestStringMasksURLUserinfoPasswords(t *testing.T) {
+func TestStringMasksURLUserinfo(t *testing.T) {
 	tests := []struct {
 		in   string
 		want string


### PR DESCRIPTION
## Summary
- mask URL userinfo passwords and Basic/Bearer authorization credentials
- retain non-HTTP URI hosts while preventing userinfo from becoming standalone indicators
- add focused regression and fuzz coverage and document the redaction scope

Supersedes #3.

## Validation
- `go test ./...`
- `go test -race ./...`
- golangci-lint v2.12.2
- govulncheck v1.6.0
- 30-second redaction fuzz run