### PR TITLE
fix(cursor): parse current transcript envelopes

### DIFF
--- a/internal/extract/cursor.go
+++ b/internal/extract/cursor.go
@@ -208,7 +208,7 @@ func (e CursorExtractor) mapLine(res *Result, src Source, sha string, st *cursor
 		// "tool"/"system"/empty records carry no standalone message body; their
 		// forensic signal is the tool call/result handled below. Only a genuinely
 		// unknown kind is a diagnostic.
-		if !isToolBearingKind(entry.kind()) {
+		if !isKnownCursorRecordKind(entry.kind()) {
 			res.diag(src.Path, line, "unhandled record kind")
 		}
 	}
@@ -221,11 +221,12 @@ func (e CursorExtractor) mapLine(res *Result, src Source, sha string, st *cursor
 	// 2. The content[] body in source order. messageEmitted guards the single
 	// concatenated message so a multi-text body still emits one event, at the
 	// position of its first text block.
-	calls := entry.Content.ToolCalls
-	results := entry.Content.ToolResults
+	content := entry.content()
+	calls := content.ToolCalls
+	results := content.ToolResults
 	ci, ri := 0, 0
 	messageEmitted := false
-	for _, kind := range entry.Content.Order {
+	for _, kind := range content.Order {
 		switch kind {
 		case cursorBlockText:
 			if !messageEmitted && ok {
@@ -271,8 +272,14 @@ func messageRole(kind string) (model.EventType, string, bool) {
 	}
 }
 
-// isToolBearingKind reports whether a non-message record kind is one Cursor uses
-// for tool/system bookkeeping (so it is not flagged as an unhandled kind).
+// isKnownCursorRecordKind reports whether a non-message record kind is known
+// bookkeeping that should not produce a standalone event or diagnostic.
+func isKnownCursorRecordKind(kind string) bool {
+	return kind == "turn_ended" || isToolBearingKind(kind)
+}
+
+// isToolBearingKind reports whether a non-message record kind is one Cursor or
+// Windsurf uses for tool/system bookkeeping.
 func isToolBearingKind(kind string) bool {
 	switch kind {
 	case "tool", "tool_result", "tool_call", "system", "":
@@ -332,7 +339,7 @@ func (e CursorExtractor) emitToolCall(res *Result, src Source, sha string, line 
 	ev.Actor = model.ActorAssistant
 	ev.Confidence = model.ConfidenceHigh
 	ev.ToolCallID = tc.callID()
-	ev.Evidence.JSONPointer = tc.Pointer
+	ev.Evidence.JSONPointer = entry.contentPointer(tc.Pointer)
 	classifyCursorTool(&ev, name, tc.input())
 	res.Events = append(res.Events, ev)
 	*block++
@@ -348,7 +355,7 @@ func (e CursorExtractor) emitToolResult(res *Result, src Source, sha string, st 
 	ev.Actor = model.ActorTool
 	ev.Confidence = model.ConfidenceHigh
 	ev.ToolCallID = to.callID()
-	ev.Evidence.JSONPointer = to.Pointer
+	ev.Evidence.JSONPointer = entry.contentPointer(to.Pointer)
 	if st.isCommandCall(to.callID()) {
 		ev.EventType = model.EventCommandResult
 		ev.ExitCode = to.exitCode()

--- a/internal/extract/cursor.go
+++ b/internal/extract/cursor.go
@@ -200,6 +200,9 @@ func (e CursorExtractor) mapLine(res *Result, src Source, sha string, st *cursor
 		res.diag(src.Path, line, "malformed JSON line")
 		return
 	}
+	if entry.Content.hasData() && entry.Message.Content.hasData() {
+		res.diag(src.Path, line, "multiple content bodies; using top-level content")
+	}
 	st.observe(res, e, src, sha, line, &entry)
 	e.indexCommandCalls(st, &entry)
 

--- a/internal/extract/cursor_entry.go
+++ b/internal/extract/cursor_entry.go
@@ -42,6 +42,8 @@ type cursorEntry struct {
 	// custom unmarshaler below normalizes both, and also lifts any tool-call and
 	// tool-result blocks out of an array body into ToolCalls/ToolResult.
 	Content cursorContent `json:"content"`
+	// Current Cursor builds wrap the same content body in a message object.
+	Message cursorMessage `json:"message"`
 
 	// Text is an alternate flat body some records carry instead of content.
 	Text string `json:"text"`
@@ -56,14 +58,28 @@ type cursorEntry struct {
 	Output     *cursorToolOut   `json:"output"`
 }
 
+// cursorMessage is the message envelope used by current Cursor transcripts.
+type cursorMessage struct {
+	Content cursorContent `json:"content"`
+}
+
+func (m *cursorMessage) UnmarshalJSON(data []byte) error {
+	raw := strings.TrimSpace(string(data))
+	if raw == "" || raw[0] != '{' {
+		return nil
+	}
+	type wire cursorMessage
+	return json.Unmarshal(data, (*wire)(m))
+}
+
 // cursorContent is the normalized body of a Cursor record. Text holds the
 // concatenated plain text; ToolCalls and ToolResults hold any tool-call /
 // tool-result blocks lifted out of an array-shaped content body. TextPointer is
 // the RFC 6901 pointer to the body in the SOURCE record: "/content" for a plain
 // string body, or "/content/<i>" naming the single text block when an array
 // body carries exactly one (so a lifted-block body still points at its real
-// source location rather than the synthetic concatenation). Each lifted tool
-// call/result carries its own source pointer (see cursorToolCall.Pointer).
+// source location rather than the synthetic concatenation). Message-wrapped
+// bodies gain their /message prefix when emitted.
 //
 // Order records the source-block order of the content[] body so the mapper can
 // emit a call before its same-record result. Each element names which bucket
@@ -75,6 +91,10 @@ type cursorContent struct {
 	ToolCalls   []cursorToolCall
 	ToolResults []cursorToolOut
 	Order       []cursorBlockKind
+}
+
+func (c *cursorContent) hasData() bool {
+	return strings.TrimSpace(c.Text) != "" || len(c.ToolCalls) > 0 || len(c.ToolResults) > 0
 }
 
 // cursorBlockKind tags one entry in cursorContent.Order with the bucket the
@@ -92,7 +112,7 @@ const (
 // its later result when the record assigns one. Pointer is the RFC 6901 pointer
 // to this call in the SOURCE record (e.g. "/content/2", "/toolCall",
 // "/toolCalls/0"); it is set by the accessors/unmarshaler, never decoded from
-// the record, so the emitted evidence reference is always source-faithful.
+// the record. Message-wrapped content gains its /message prefix when emitted.
 type cursorToolCall struct {
 	Type    string                     `json:"type"`
 	Name    string                     `json:"name"`
@@ -259,6 +279,23 @@ func (e *cursorEntry) time() string {
 	return timeString(e.CreatedAt)
 }
 
+// content returns the record's content body. Older transcripts store it at the
+// top level; current builds place it under message.
+func (e *cursorEntry) content() *cursorContent {
+	if e.Content.hasData() {
+		return &e.Content
+	}
+	return &e.Message.Content
+}
+
+// contentPointer maps a normalized content pointer back to its source location.
+func (e *cursorEntry) contentPointer(pointer string) string {
+	if e.Content.hasData() || (pointer != "/content" && !strings.HasPrefix(pointer, "/content/")) {
+		return pointer
+	}
+	return "/message" + pointer
+}
+
 // timeString returns v as a timestamp only when it is already a string; a
 // numeric epoch returns "" (see time() for why numbat does not guess a format).
 func timeString(v any) string {
@@ -270,11 +307,12 @@ func timeString(v any) string {
 
 // text returns the record's body, preferring the structured content text over
 // the flat Text field, together with the RFC 6901 pointer to it in the SOURCE
-// record. The content body points at "/content" or "/content/<i>" (set by the
-// unmarshaler); the flat fallback points at "/text".
+// record. Content pointers reflect either the top-level or message-wrapped body;
+// the flat fallback points at "/text".
 func (e *cursorEntry) text() (string, string) {
-	if s := strings.TrimSpace(e.Content.Text); s != "" {
-		return s, e.Content.TextPointer
+	content := e.content()
+	if s := strings.TrimSpace(content.Text); s != "" {
+		return s, e.contentPointer(content.TextPointer)
 	}
 	if s := strings.TrimSpace(e.Text); s != "" {
 		return s, "/text"
@@ -284,12 +322,11 @@ func (e *cursorEntry) text() (string, string) {
 
 // toolCalls returns every tool invocation the record carries, gathered from the
 // array-content blocks, the top-level toolCalls list, and a single top-level
-// toolCall, in that order. Each call carries its source pointer: array blocks
-// keep the "/content/<i>" set at unmarshal time, the top-level list points at
-// "/toolCalls/<i>", and a lone top-level call points at "/toolCall".
+// toolCall, in that order. Content-block pointers are adjusted at emission; the
+// top-level list points at "/toolCalls/<i>", and a lone call at "/toolCall".
 func (e *cursorEntry) toolCalls() []cursorToolCall {
 	var calls []cursorToolCall
-	calls = append(calls, e.Content.ToolCalls...)
+	calls = append(calls, e.content().ToolCalls...)
 	for i := range e.ToolCalls {
 		tc := e.ToolCalls[i]
 		tc.Pointer = fmt.Sprintf("/toolCalls/%d", i)

--- a/internal/extract/cursor_test.go
+++ b/internal/extract/cursor_test.go
@@ -133,6 +133,18 @@ func TestExtractCursorToleratesNonObjectMessageEnvelope(t *testing.T) {
 	}
 }
 
+func TestExtractCursorDiagnosesMultipleContentBodies(t *testing.T) {
+	const body = `{"role":"assistant","content":"top-level text","message":{"content":[{"type":"tool_use","name":"Read","input":{"path":"/workspace/hidden.txt"}}]}}`
+	res := extractCursor(t, body, ProfileEvidence)
+	if len(res.Diagnostics) != 1 || !strings.Contains(res.Diagnostics[0].Msg, "multiple content bodies") {
+		t.Fatalf("diagnostics = %+v, want one multiple-content warning", res.Diagnostics)
+	}
+	acts := activityEvents(res.Events)
+	if len(acts) != 1 || acts[0].EventType != model.EventMessageAssistant || acts[0].ContentPreview != "top-level text" {
+		t.Fatalf("activity events = %s, want the top-level assistant message", dumpEvents(acts))
+	}
+}
+
 // A tool result whose call id was never a shell command stays a generic
 // tool.result (never a command.result), and a structurally-marked failure is
 // tagged tool_error. This covers the non-command correlation branch.

--- a/internal/extract/cursor_test.go
+++ b/internal/extract/cursor_test.go
@@ -88,6 +88,51 @@ func TestExtractCursorMapsShapesWithCursorIdentity(t *testing.T) {
 	assertUniqueEventIDs(t, res.Events)
 }
 
+// Current Cursor transcripts wrap content blocks in message and end each turn
+// with a bookkeeping record. Both the text and tool call must still surface,
+// while turn_ended should be silent.
+func TestExtractCursorCurrentMessageEnvelope(t *testing.T) {
+	const body = `{"role":"user","message":{"content":[{"type":"text","text":"inspect the readme"}]}}
+{"role":"assistant","message":{"content":[{"type":"text","text":"I will open it."},{"type":"tool_use","name":"Read","input":{"path":"/workspace/README.md"}}]}}
+{"type":"turn_ended","status":"success"}`
+	res := extractCursor(t, body, ProfileEvidence)
+	if len(res.Diagnostics) != 0 {
+		t.Fatalf("unexpected diagnostics: %+v", res.Diagnostics)
+	}
+
+	acts := activityEvents(res.Events)
+	wantTypes := []model.EventType{
+		model.EventPromptUser,
+		model.EventMessageAssistant,
+		model.EventFileRead,
+	}
+	wantPointers := []string{
+		"/message/content/0",
+		"/message/content/0",
+		"/message/content/1",
+	}
+	if len(acts) != len(wantTypes) {
+		t.Fatalf("got %d activity events, want %d:\n%s", len(acts), len(wantTypes), dumpEvents(res.Events))
+	}
+	for i := range wantTypes {
+		if acts[i].EventType != wantTypes[i] || acts[i].Evidence.JSONPointer != wantPointers[i] {
+			t.Errorf("event %d = {%s pointer=%q}, want {%s pointer=%q}",
+				i, acts[i].EventType, acts[i].Evidence.JSONPointer, wantTypes[i], wantPointers[i])
+		}
+	}
+	if acts[2].FilePath != "/workspace/README.md" || acts[2].ToolName != "Read" {
+		t.Errorf("file event = {path=%q tool=%q}, want {/workspace/README.md Read}", acts[2].FilePath, acts[2].ToolName)
+	}
+	assertUniqueEventIDs(t, res.Events)
+}
+
+func TestExtractCursorToleratesNonObjectMessageEnvelope(t *testing.T) {
+	res := extractCursor(t, `{"type":"system","message":"bookkeeping"}`, ProfileEvidence)
+	if len(res.Diagnostics) != 0 || len(res.Events) != 0 {
+		t.Fatalf("scalar message produced output: events=%s diagnostics=%+v", dumpEvents(res.Events), res.Diagnostics)
+	}
+}
+
 // A tool result whose call id was never a shell command stays a generic
 // tool.result (never a command.result), and a structurally-marked failure is
 // tagged tool_error. This covers the non-command correlation branch.


### PR DESCRIPTION
## Summary
- parse current Cursor transcripts that wrap text and tool blocks under `message.content`
- preserve source-faithful evidence pointers and existing top-level transcript shapes
- ignore `turn_ended` bookkeeping instead of reporting an unknown record

## Reproduction
With Cursor 3.14.27, three local transcripts previously emitted zero events and three warnings. They now emit 12 normalized events with no parser warnings.

## Verification
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run` and `fmt --diff` (v2.12.2)
- `FuzzCursorExtract` for 15 seconds
- local Cursor scan and timeline

Addresses the remaining Cursor item in #6.