### PR TITLE
fix(rules): cover managed-mcp.json in tamper.agent_config_write

### DIFF
--- a/rules/catalog_test.go
+++ b/rules/catalog_test.go
@@ -140,6 +140,11 @@ func TestTamperRules(t *testing.T) {
 	runCases(t, eng, []ruleCase{
 		{"claude settings write", write("/Users/dev/.claude/settings.json"), "tamper.agent_config_write"},
 		{"claude settings.local write", write("/Users/dev/.claude/settings.local.json"), "tamper.agent_config_write"},
+		{"claude managed-mcp delete macOS", model.Event{EventType: model.EventFileDelete, FilePath: "/Library/Application Support/ClaudeCode/managed-mcp.json"}, "tamper.agent_config_write"},
+		{"claude managed-mcp write Linux", write("/etc/claude-code/managed-mcp.json"), "tamper.agent_config_write"},
+		{"claude managed-mcp write Windows", write("C:/Program Files/ClaudeCode/managed-mcp.json"), "tamper.agent_config_write"},
+		{"claude managed-mcp redirect", cmd("echo '{}' > /etc/claude-code/managed-mcp.json"), "tamper.agent_config_write"},
+		{"claude managed-mcp remove", cmd(`rm -f "/Library/Application Support/ClaudeCode/managed-mcp.json"`), "tamper.agent_config_write"},
 		{"codex hooks write", write("/Users/dev/.codex/hooks.json"), "tamper.agent_config_write"},
 		{"gemini installer hooks write", write("/Users/dev/.gemini/config/hooks.json"), "tamper.agent_config_write"},
 		{"gemini system settings write", write("/etc/gemini-cli/settings.json"), "tamper.agent_config_write"},

--- a/rules/tamper/agent_config_write.yaml
+++ b/rules/tamper/agent_config_write.yaml
@@ -1,5 +1,5 @@
 id: tamper.agent_config_write
-version: "1.7"
+version: "1.8"
 enabled: true
 title: Agent hook or settings file targeted
 description: |-
@@ -12,9 +12,9 @@ expr: |-
     event.file_path.matches(
       "(?i)(^|/)(" +
       "\\.claude/settings(\\.local)?\\.json|" +
-      "etc/claude-code/managed-settings(\\.d/[^/]+)?\\.json|" +
-      "Library/Application Support/ClaudeCode/managed-settings(\\.d/[^/]+)?\\.json|" +
-      "Program Files/ClaudeCode/managed-settings(\\.d/[^/]+)?\\.json|" +
+      "etc/claude-code/managed-(settings(\\.d/[^/]+)?|mcp)\\.json|" +
+      "Library/Application Support/ClaudeCode/managed-(settings(\\.d/[^/]+)?|mcp)\\.json|" +
+      "Program Files/ClaudeCode/managed-(settings(\\.d/[^/]+)?|mcp)\\.json|" +
       "\\.codex/hooks\\.json|etc/codex/(hooks\\.json|requirements\\.toml)|" +
       "ProgramData/OpenAI/Codex/requirements\\.toml|" +
       "\\.gemini/(settings\\.json|config/hooks\\.json)|" +
@@ -54,8 +54,8 @@ expr: |-
         redirect.op in ["write", "append"] &&
         redirect.target.matches(
           "(?i)(^|[\\\\/])(" +
-          "\\.claude[\\\\/]settings(\\.local)?\\.json|etc[\\\\/]claude-code[\\\\/]managed-settings(\\.d[\\\\/][^\\\\/]+)?\\.json|" +
-          "Library[\\\\/]Application Support[\\\\/]ClaudeCode[\\\\/]managed-settings(\\.d[\\\\/][^\\\\/]+)?\\.json|Program Files[\\\\/]ClaudeCode[\\\\/]managed-settings(\\.d[\\\\/][^\\\\/]+)?\\.json|" +
+          "\\.claude[\\\\/]settings(\\.local)?\\.json|etc[\\\\/]claude-code[\\\\/]managed-(settings(\\.d[\\\\/][^\\\\/]+)?|mcp)\\.json|" +
+          "Library[\\\\/]Application Support[\\\\/]ClaudeCode[\\\\/]managed-(settings(\\.d[\\\\/][^\\\\/]+)?|mcp)\\.json|Program Files[\\\\/]ClaudeCode[\\\\/]managed-(settings(\\.d[\\\\/][^\\\\/]+)?|mcp)\\.json|" +
           "\\.codex[\\\\/]hooks\\.json|etc[\\\\/]codex[\\\\/](hooks\\.json|requirements\\.toml)|ProgramData[\\\\/]OpenAI[\\\\/]Codex[\\\\/]requirements\\.toml|" +
           "\\.gemini[\\\\/](settings\\.json|config[\\\\/]hooks\\.json)|etc[\\\\/]gemini-cli[\\\\/]settings\\.json|Library[\\\\/]Application Support[\\\\/]GeminiCli[\\\\/]settings\\.json|ProgramData[\\\\/]gemini-cli[\\\\/]settings\\.json|" +
           "\\.cursor[\\\\/]hooks\\.json|etc[\\\\/]cursor[\\\\/]hooks\\.json|Library[\\\\/]Application Support[\\\\/]Cursor[\\\\/]hooks\\.json|ProgramData[\\\\/]Cursor[\\\\/]hooks\\.json|" +
@@ -144,7 +144,7 @@ expr: |-
         i < command.argv.size() &&
         command.argv[i].matches(
           "(?i)(^|[\\\\/])(" +
-          "\\.claude[\\\\/]settings(\\.local)?\\.json|etc[\\\\/]claude-code[\\\\/]managed-settings(\\.d[\\\\/][^\\\\/]+)?\\.json|Library[\\\\/]Application Support[\\\\/]ClaudeCode[\\\\/]managed-settings(\\.d[\\\\/][^\\\\/]+)?\\.json|Program Files[\\\\/]ClaudeCode[\\\\/]managed-settings(\\.d[\\\\/][^\\\\/]+)?\\.json|" +
+          "\\.claude[\\\\/]settings(\\.local)?\\.json|etc[\\\\/]claude-code[\\\\/]managed-(settings(\\.d[\\\\/][^\\\\/]+)?|mcp)\\.json|Library[\\\\/]Application Support[\\\\/]ClaudeCode[\\\\/]managed-(settings(\\.d[\\\\/][^\\\\/]+)?|mcp)\\.json|Program Files[\\\\/]ClaudeCode[\\\\/]managed-(settings(\\.d[\\\\/][^\\\\/]+)?|mcp)\\.json|" +
           "\\.codex[\\\\/]hooks\\.json|etc[\\\\/]codex[\\\\/](hooks\\.json|requirements\\.toml)|ProgramData[\\\\/]OpenAI[\\\\/]Codex[\\\\/]requirements\\.toml|" +
           "\\.gemini[\\\\/](settings\\.json|config[\\\\/]hooks\\.json)|etc[\\\\/]gemini-cli[\\\\/]settings\\.json|Library[\\\\/]Application Support[\\\\/]GeminiCli[\\\\/]settings\\.json|ProgramData[\\\\/]gemini-cli[\\\\/]settings\\.json|" +
           "\\.cursor[\\\\/]hooks\\.json|etc[\\\\/]cursor[\\\\/]hooks\\.json|Library[\\\\/]Application Support[\\\\/]Cursor[\\\\/]hooks\\.json|ProgramData[\\\\/]Cursor[\\\\/]hooks\\.json|" +


### PR DESCRIPTION
## Summary

`tamper.agent_config_write` matched Claude Code's `managed-settings.json` in the
three admin directories (`/etc/claude-code/`, `/Library/Application Support/ClaudeCode/`,
`C:\Program Files\ClaudeCode\`) but did **not** match `managed-mcp.json`, the
enterprise control that restricts which MCP servers may load. It ships to the
same three directories. Per Anthropic's docs, deploying a `managed-mcp.json` with
an empty server map blocks every MCP server fleet-wide — so deleting that one
file re-enables every MCP server on the endpoint. That mutation is squarely
defense impairment, which is the rule's existing `attack.t1562.001` scope.

This extends the Claude `managed-settings` fragment to
`managed-(settings(\.d/…)?|mcp)\.json` in all three regex branches (file-path,
shell redirect, shell argv), scoped to those admin directories only. User/project
MCP stores (`~/.claude.json`, `~/.cursor/mcp.json`, `~/.codex/config.toml`) are
deliberately left out — they are capability acquisition, not defense impairment
(a documented false negative, consistent with the rule's precision policy). This
is the conservative line the issue proposed.

Fixes #24

## Changes

- `rules/tamper/agent_config_write.yaml`: add `managed-mcp.json` alongside
  `managed-settings.json` for the three ClaudeCode admin dirs, in the file-path,
  redirect, and argv match branches. Bump rule `version` 1.7 → 1.8.
- `rules/catalog_test.go`: add `TestTamperRules` cases for `managed-mcp.json`
  covering delete/write (file-path branch, macOS/Linux/Windows dirs), `echo >`
  (redirect branch), and `rm -f` (argv branch).

## Scope / precision

- Existing `managed-settings.json` and `managed-settings.d/<file>.json` matches
  are unchanged (no regression). `managed-mcp.json` has no `.d/` drop-in arm, so
  the addition is a single filename, not a directory tree.
- The nested-repo exclusion still applies to `managed-mcp.json`, so a repository
  checkout containing `…/Library/Application Support/ClaudeCode/managed-mcp.json`
  stays quiet, exactly like the existing `managed-settings.json` negative.
- No wire-contract/schema change; rule-version bump only.

## Test verification (RED → GREEN)

RED — new tests on the unmodified rule (`go test ./rules/ -run TestTamperRules`):

```
--- FAIL: TestTamperRules (0.42s)
    --- FAIL: TestTamperRules/claude_managed-mcp_delete_macOS
        builtin_test.go:693: expected tamper.agent_config_write to fire, got []
    --- FAIL: TestTamperRules/claude_managed-mcp_write_Linux
        builtin_test.go:693: expected tamper.agent_config_write to fire, got []
    --- FAIL: TestTamperRules/claude_managed-mcp_write_Windows
        builtin_test.go:693: expected tamper.agent_config_write to fire, got []
    --- FAIL: TestTamperRules/claude_managed-mcp_redirect
        builtin_test.go:693: expected tamper.agent_config_write to fire, got []
    --- FAIL: TestTamperRules/claude_managed-mcp_remove
        builtin_test.go:693: expected tamper.agent_config_write to fire, got []
FAIL
```

GREEN — same tests after the rule change:

```
--- PASS: TestTamperRules/claude_managed-mcp_delete_macOS (0.00s)
--- PASS: TestTamperRules/claude_managed-mcp_write_Linux (0.00s)
--- PASS: TestTamperRules/claude_managed-mcp_write_Windows (0.00s)
--- PASS: TestTamperRules/claude_managed-mcp_redirect (0.00s)
--- PASS: TestTamperRules/claude_managed-mcp_remove (0.00s)
ok  	github.com/perplexityai/numbat/rules	0.511s
```

## Verification commands run (Go 1.26.5)

```
go mod tidy && git diff --exit-code -- go.mod go.sum
gofmt -l .            # empty
go vet ./...
go test -race ./...   # all packages ok
go build -buildvcs=false ./cmd/numbat
golangci-lint run     # 0 issues
golangci-lint fmt --diff
govulncheck ./...      # No vulnerabilities found
```
