### PR TITLE
ci: run every fuzz target, and fix the projection bug that surfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,14 +104,30 @@ jobs:
       # Bounded fuzzing: each target runs briefly to surface crashers without
       # turning into an open-ended job. The parsers and the redaction decoder
       # must survive arbitrary and malformed input without panicking.
+      #
+      # Every FuzzXxx target in the tree is listed here. A target that exists
+      # but is never run is a gap that looks like coverage: the shell-analysis
+      # target below was defined and unexercised, and a bounded run surfaced a
+      # projection-invariant failure in under three minutes.
       - name: fuzz extract parsers
         run: |
-          for t in FuzzClaudeExtract FuzzCodexExtract FuzzGeminiExtract FuzzPiExtract FuzzKimiCodeExtract; do
+          for t in FuzzClaudeExtract FuzzCodexExtract FuzzGeminiExtract FuzzPiExtract \
+                   FuzzKimiCodeExtract FuzzGeminiSessionExtract FuzzCursorExtract \
+                   FuzzWindsurfExtract FuzzOpenCodeExtract FuzzOpenClawExtract \
+                   FuzzCodexCodeModeExecCommand; do
             go test -run='^$' -fuzz="^${t}$" -fuzztime=30s ./internal/extract/
           done
 
       - name: fuzz redaction decoder
-        run: go test -run='^$' -fuzz='^FuzzString$' -fuzztime=30s ./internal/redact/
+        run: |
+          for t in FuzzString FuzzJSONProducesValidJSON; do
+            go test -run='^$' -fuzz="^${t}$" -fuzztime=30s ./internal/redact/
+          done
+
+      # Guards the command projection every shell rule matches against: a parse
+      # that silently drops a command is a detection gap, not just a crash.
+      - name: fuzz shell command analysis
+        run: go test -run='^$' -fuzz='^FuzzAnalyzeShellCommands$' -fuzztime=30s ./internal/rule/
 
       - name: fuzz OTLP decoder
         run: go test -run='^$' -fuzz='^FuzzOTLPLogs$' -fuzztime=30s ./internal/otel/

--- a/internal/rule/powershell.go
+++ b/internal/rule/powershell.go
@@ -476,6 +476,15 @@ func (a *shellAnalyzer) addPowerShellSegment(segment string, depth int, wrappers
 		a.report(errors.New("shell command analysis: unsupported or malformed PowerShell command"))
 		return
 	}
+	// The call operator admits a quoted token so "& 'C:\path with space.exe'"
+	// projects, but an empty quoted target carries no executable, assignment,
+	// or redirect. Such a command names nothing a rule can match, so drop it
+	// and mark the analysis uncertain rather than seating a phantom entry that
+	// still consumes one of the maxShellCommands slots.
+	if command.Executable == "" && len(command.Assignments) == 0 && len(command.Redirects) == 0 {
+		a.report(errors.New("shell command analysis: unsupported or malformed PowerShell command"))
+		return
+	}
 	if recognizedPowerShellAlias(command.Executable) {
 		command.enforcementUnsafe = true
 	}

--- a/internal/rule/shell_test.go
+++ b/internal/rule/shell_test.go
@@ -1559,3 +1559,23 @@ func encodePowerShell(source string) string {
 	}
 	return base64.StdEncoding.EncodeToString(data)
 }
+
+// TestPowerShellEmptyCallOperatorTargetIsNotProjected covers the projection
+// invariant: the call operator admits a quoted token, but an empty quoted
+// target names nothing. It must not seat a phantom command that carries no
+// executable, assignment, or redirect and still consumes a maxShellCommands
+// slot. Found by FuzzAnalyzeShellCommands.
+func TestPowerShellEmptyCallOperatorTargetIsNotProjected(t *testing.T) {
+	t.Parallel()
+	for _, source := range []string{`@(&''&&`, `& ''`, `& ""`} {
+		t.Run(source, func(t *testing.T) {
+			t.Parallel()
+			commands, _, _ := analyzeShellCommands(source)
+			for i, command := range commands {
+				if command.Executable == "" && len(command.Assignments) == 0 && len(command.Redirects) == 0 {
+					t.Fatalf("command %d is an empty projection for %q: %#v", i, source, command)
+				}
+			}
+		})
+	}
+}

--- a/internal/rule/testdata/fuzz/FuzzAnalyzeShellCommands/7f06614fcda00e6b
+++ b/internal/rule/testdata/fuzz/FuzzAnalyzeShellCommands/7f06614fcda00e6b
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("@(&''&&")


### PR DESCRIPTION
## What

The fuzz job runs 7 of the 15 `FuzzXxx` targets defined in the tree. This lists all 15, and fixes the one real bug that enabling them uncovers.

Newly wired: `FuzzAnalyzeShellCommands`, `FuzzGeminiSessionExtract`, `FuzzCursorExtract`, `FuzzWindsurfExtract`, `FuzzOpenCodeExtract`, `FuzzOpenClawExtract`, `FuzzCodexCodeModeExecCommand`, `FuzzJSONProducesValidJSON`.

## Why the fix is in the same commit

`FuzzAnalyzeShellCommands` fails on current `main` in 148 seconds, so it cannot be enabled on its own:

```
string("@(&''&&")
shell_test.go:1473: command 0 is empty for source length 7
```

`addPowerShellSegment` admits a quoted token when the `&` call operator is present, so `& 'C:\path with space.exe'` projects correctly. An empty quoted target passes that same guard and yields a command with no executable, assignment, or redirect. It names nothing a rule can match and still consumes one of the 64 `maxShellCommands` slots. The fix drops it and reports the analysis as uncertain, which is the existing behaviour for input that cannot be projected.

The crasher is kept as a seed corpus file.

I checked whether this was exploitable before writing it up as a plain bug: padding with these phantom commands is no more effective at pushing a real command out of the projection than padding with benign `echo x` commands, since both hit the same deliberate `maxShellCommands` bound and both mark the analysis enforcement-unsafe. **I am not claiming a security impact for it.**

## Why `FuzzAnalyzeShellCommands` in particular

It guards the command projection every shell rule matches against. A parse that silently drops a command is a detection gap rather than a crash, which is the failure mode least likely to be caught by the other suites.

## Cost

8 more targets at 30s adds roughly 4 minutes, leaving the job around 10 minutes against its existing 15-minute timeout. Happy to drop `-fuzztime` to 20s if you would rather keep more headroom.

## Verification

```
gofmt -l .                          # clean
go vet ./...
go test -race ./...
go build -buildvcs=false ./cmd/numbat
golangci-lint run                   # 0 issues (v2.12.2)
golangci-lint fmt --diff            # clean
govulncheck ./...                   # no vulnerabilities (v1.6.0)
```

Plus 4 minutes / 8.1M executions of `FuzzAnalyzeShellCommands` after the fix, with no crashers.

No schema, wire-contract, or rule-version effects. `internal/archguard` passes unmodified.