### PR TITLE
feat(content): add explicit message output controls

### DIFF
--- a/cmd/numbat/collect.go
+++ b/cmd/numbat/collect.go
@@ -61,6 +61,7 @@ func runCollect(args []string, stdout, stderr io.Writer) int {
 	caseID := fs.String("case-id", "", "case identifier stamped on every emitted event and derived finding")
 	var emitValues multiFlag
 	fs.Var(&emitValues, "emit", emitFlagHelp())
+	contentFlag := fs.String("content", "preview", contentFlagHelp())
 	var outputValues multiFlag
 	fs.Var(&outputValues, "output", outputFlagHelp(outputModeStdout))
 	outputFile := fs.String("output-file", "", "destination path (required when --output includes file)")
@@ -75,7 +76,7 @@ func runCollect(args []string, stdout, stderr io.Writer) int {
 	var rf ruleFlags
 	rf.register(fs)
 	fs.Usage = func() {
-		fmt.Fprintln(stderr, "usage: numbat collect [--addr 127.0.0.1:4318] [--emit KIND ...] [--output SINK ...] [--case-id ID] [--rules-dir DIR ...] [--no-builtin-rules]")
+		fmt.Fprintln(stderr, "usage: numbat collect [--addr 127.0.0.1:4318] [--emit KIND ...] [--content preview|full] [--output SINK ...] [--case-id ID] [--rules-dir DIR ...] [--no-builtin-rules]")
 		fmt.Fprintln(stderr, "\nReceives live OTLP/HTTP protobuf logs from supported AI agents and emits")
 		fmt.Fprintln(stderr, "selected records through the shared detection pipeline.")
 		fmt.Fprintln(stderr, "\nAt the default address, send logs to http://"+defaultOTLPAddr+otlpLogsPath+".")
@@ -97,6 +98,17 @@ func runCollect(args []string, stdout, stderr io.Writer) int {
 
 	sel, err := parseEmit(emitValues)
 	if err != nil {
+		fmt.Fprintf(stderr, "collect: %v\n", err)
+		fs.Usage()
+		return 2
+	}
+	content, err := parseContentMode(*contentFlag)
+	if err != nil {
+		fmt.Fprintf(stderr, "collect: %v\n", err)
+		fs.Usage()
+		return 2
+	}
+	if err := validateContentSelection(content, sel); err != nil {
 		fmt.Fprintf(stderr, "collect: %v\n", err)
 		fs.Usage()
 		return 2
@@ -137,7 +149,7 @@ func runCollect(args []string, stdout, stderr io.Writer) int {
 	}
 
 	rid := runID()
-	em := output.NewWithSink(sink, stderr, rid)
+	em := output.NewWithSink(sink, stderr, rid, contentEmitterOptions(content)...)
 	rcv, err := newCollector(collectorConfig{
 		emit:      em,
 		runID:     rid,

--- a/cmd/numbat/collect_test.go
+++ b/cmd/numbat/collect_test.go
@@ -17,6 +17,7 @@ import (
 
 	"google.golang.org/protobuf/encoding/protowire"
 
+	"github.com/perplexityai/numbat/internal/model"
 	"github.com/perplexityai/numbat/internal/output"
 )
 
@@ -169,6 +170,35 @@ func TestCollectHandlerMapsAndProcesses(t *testing.T) {
 	}
 	if findings < 1 {
 		t.Errorf("expected at least one finding for curl|sh, got %d", findings)
+	}
+}
+
+func TestCollectFullContentProjection(t *testing.T) {
+	var records, diags bytes.Buffer
+	em := output.New(&records, &diags, "run-test", output.WithFullContent())
+	c, err := newCollector(collectorConfig{
+		emit:  em,
+		runID: "run-test",
+		sel:   emitSelection{events: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret := "sk-abcdefghijklmnopqrstuvwxyz0123456789"
+	prompt := strings.Repeat("ordinary context ", 20) + secret
+	body := buildOTLPLogs("claude-code", []map[string]string{{
+		"__event_name":  "gen_ai.user.message",
+		"gen_ai.prompt": prompt,
+	}})
+	if rr := postLogs(t, c, body, contentTypeProtobuf); rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	var ev model.Event
+	if err := json.Unmarshal(bytes.TrimSpace(records.Bytes()), &ev); err != nil {
+		t.Fatal(err)
+	}
+	if ev.EventType != model.EventPromptUser || ev.Content == "" || strings.Contains(ev.Content, secret) || ev.ContentBytes != len(prompt) {
+		t.Fatalf("OTLP content projection = %+v", ev)
 	}
 }
 

--- a/cmd/numbat/content.go
+++ b/cmd/numbat/content.go
@@ -24,6 +24,17 @@ func parseContentMode(value string) (contentMode, error) {
 	}
 }
 
+func applyDeprecatedProfile(value string, includeReasoning bool) (bool, error) {
+	switch value {
+	case "", "evidence":
+		return includeReasoning, nil
+	case "full":
+		return true, nil
+	default:
+		return false, fmt.Errorf("invalid --profile %q: want evidence|full", value)
+	}
+}
+
 func validateContentSelection(mode contentMode, sel emitSelection) error {
 	if mode == contentFull && !sel.events {
 		return fmt.Errorf("--content full requires --emit events or --emit all")

--- a/cmd/numbat/content.go
+++ b/cmd/numbat/content.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/perplexityai/numbat/internal/output"
+)
+
+type contentMode uint8
+
+const (
+	contentPreview contentMode = iota
+	contentFull
+)
+
+func parseContentMode(value string) (contentMode, error) {
+	switch value {
+	case "preview":
+		return contentPreview, nil
+	case "full":
+		return contentFull, nil
+	default:
+		return contentPreview, fmt.Errorf("invalid --content %q: want preview|full", value)
+	}
+}
+
+func validateContentSelection(mode contentMode, sel emitSelection) error {
+	if mode == contentFull && !sel.events {
+		return fmt.Errorf("--content full requires --emit events or --emit all")
+	}
+	return nil
+}
+
+func contentFlagHelp() string {
+	return "conversation content in event output: preview|full (full is redacted and bounded to 1 MiB)"
+}
+
+func contentEmitterOptions(mode contentMode) []output.EmitterOption {
+	if mode == contentFull {
+		return []output.EmitterOption{output.WithFullContent()}
+	}
+	return nil
+}

--- a/cmd/numbat/hook.go
+++ b/cmd/numbat/hook.go
@@ -87,6 +87,7 @@ func runHookEvent(event string, args []string, stdin io.Reader, stdout, stderr i
 	caseID := fs.String("case-id", "", "case identifier stamped on every emitted event and derived finding")
 	var emitValues multiFlag
 	fs.Var(&emitValues, "emit", emitFlagHelp()+"; enforce mode requires findings")
+	contentFlag := fs.String("content", "preview", contentFlagHelp())
 	var outputValues multiFlag
 	fs.Var(&outputValues, "output", outputFlagHelp(outputModeStdout)+"; stdout mode writes records to hook stderr and is unavailable in enforce mode")
 	outputFile := fs.String("output-file", "", "destination path (required when --output includes file)")
@@ -107,7 +108,7 @@ func runHookEvent(event string, args []string, stdin io.Reader, stdout, stderr i
 	var rf ruleFlags
 	rf.register(fs)
 	fs.Usage = func() {
-		fmt.Fprintln(stderr, "usage: numbat hook EVENT --agent "+hook.AgentUsage()+" [--emit KIND ...] [--output SINK ...] [--case-id ID] [--rules-dir DIR ...] [--no-builtin-rules]")
+		fmt.Fprintln(stderr, "usage: numbat hook EVENT --agent "+hook.AgentUsage()+" [--emit KIND ...] [--content preview|full] [--output SINK ...] [--case-id ID] [--rules-dir DIR ...] [--no-builtin-rules]")
 		printHTTPAuthEnvHelp(stderr, false)
 		fs.PrintDefaults()
 	}
@@ -135,6 +136,15 @@ func runHookEvent(event string, args []string, stdin io.Reader, stdout, stderr i
 	}
 	sel, err := parseEmit(emitValues)
 	if err != nil {
+		fmt.Fprintf(stderr, "hook: %v\n", err)
+		return 0
+	}
+	content, err := parseContentMode(*contentFlag)
+	if err != nil {
+		fmt.Fprintf(stderr, "hook: %v\n", err)
+		return 0
+	}
+	if err := validateContentSelection(content, sel); err != nil {
 		fmt.Fprintf(stderr, "hook: %v\n", err)
 		return 0
 	}
@@ -183,6 +193,7 @@ func runHookEvent(event string, args []string, stdin io.Reader, stdout, stderr i
 	deny, reason, denyAgent, err := handleHook(event, lc, *agentFlag, sourceAgent, stdin, stderr, hookOptions{
 		caseID:     *caseID,
 		sel:        sel,
+		content:    content,
 		stateDB:    *stateDB,
 		modes:      outputValues,
 		file:       *outputFile,
@@ -235,6 +246,7 @@ func runHookEvent(event string, args []string, stdin io.Reader, stdout, stderr i
 type hookOptions struct {
 	caseID     string
 	sel        emitSelection
+	content    contentMode
 	stateDB    string
 	modes      []string
 	file       string
@@ -300,9 +312,9 @@ func handleHook(event string, lc hook.Lifecycle, agent, sourceAgent string, stdi
 	run := runID()
 	var em *output.Emitter
 	if opts.enforce {
-		em = output.NewWithSinkAndDiagnostics(sink, run)
+		em = output.NewWithSinkAndDiagnostics(sink, run, contentEmitterOptions(opts.content)...)
 	} else {
-		em = output.NewWithSink(sink, stderr, run)
+		em = output.NewWithSink(sink, stderr, run, contentEmitterOptions(opts.content)...)
 	}
 	closeWithDiagnostic := func(err error) error {
 		em.Diag("error", err.Error())

--- a/cmd/numbat/hook_install.go
+++ b/cmd/numbat/hook_install.go
@@ -39,6 +39,7 @@ func runHookAdmin(action string, args []string, stdout, stderr io.Writer) int {
 	var (
 		enforce           bool
 		emitValues        multiFlag
+		contentValue      = "preview"
 		outputValues      multiFlag
 		outputFileValue   string
 		httpURL           string
@@ -55,6 +56,7 @@ func runHookAdmin(action string, args []string, stdout, stderr io.Writer) int {
 	if action == "install" {
 		fs.BoolVar(&enforce, "enforce", false, "install in enforce mode for agents with blocking support: deny supported pre-action requests when a rule marked enforce=true matches; requires an enabled enforce=true rule in the effective catalog (default: monitor only)")
 		fs.Var(&emitValues, "emit", "records emitted by live integrations: findings, events, indicators, or all (repeatable; default findings; enforce mode requires findings)")
+		fs.StringVar(&contentValue, "content", "preview", contentFlagHelp())
 		fs.Var(&outputValues, "output", outputFlagHelp(outputModeFile)+"; stdout mode writes records to hook stderr and is unavailable in enforce mode")
 		fs.StringVar(&outputFileValue, "output-file", "", "destination path when --output includes file (default findings.ndjson, or records.ndjson when --emit includes events/indicators)")
 		fs.StringVar(&httpURL, "http-url", "", "ingest URL (required when --output includes http)")
@@ -75,7 +77,7 @@ func runHookAdmin(action string, args []string, stdout, stderr io.Writer) int {
 		}
 		fmt.Fprintf(stderr, "usage: numbat hook %s %s [--settings PATH] [--managed]", action, agentArg)
 		if action == "install" {
-			fmt.Fprint(stderr, " [--emit KIND ...] [--output SINK ...] [--rules-dir DIR ...] [--no-builtin-rules] [--enforce]")
+			fmt.Fprint(stderr, " [--emit KIND ...] [--content preview|full] [--output SINK ...] [--rules-dir DIR ...] [--no-builtin-rules] [--enforce]")
 		}
 		fmt.Fprintln(stderr)
 		switch action {
@@ -174,8 +176,14 @@ func runHookAdmin(action string, args []string, stdout, stderr io.Writer) int {
 	}
 	var installOpts hook.InstallOptions
 	if action == "install" {
+		content, parseErr := parseContentMode(contentValue)
+		if parseErr != nil {
+			fmt.Fprintf(stderr, "hook install: %v\n", parseErr)
+			return 2
+		}
 		args, err := installRuntimeArgs(installRuntimeConfig{
 			emit:          emitValues,
+			content:       content,
 			modes:         outputValues,
 			file:          outputFileValue,
 			httpURL:       httpURL,
@@ -274,6 +282,7 @@ func runHookAction(action, agent, path, binary string, installOpts hook.InstallO
 
 type installRuntimeConfig struct {
 	emit          []string
+	content       contentMode
 	modes         []string
 	file          string
 	httpURL       string
@@ -294,6 +303,9 @@ type installRuntimeConfig struct {
 func installRuntimeArgs(cfg installRuntimeConfig, home string) ([]string, error) {
 	emitSel, err := parseEmit(cfg.emit)
 	if err != nil {
+		return nil, err
+	}
+	if err := validateContentSelection(cfg.content, emitSel); err != nil {
 		return nil, err
 	}
 	sinks, err := parseOutputSinks(cfg.modes, outputModeFile)
@@ -344,6 +356,9 @@ func installRuntimeArgs(cfg installRuntimeConfig, home string) ([]string, error)
 		for _, mode := range emitSel.canonicalModes() {
 			args = append(args, "--emit", mode)
 		}
+	}
+	if cfg.content == contentFull {
+		args = append(args, "--content=full")
 	}
 	if !sinks.http {
 		for _, name := range httpOnlyInstallFlagNames() {

--- a/cmd/numbat/hook_test.go
+++ b/cmd/numbat/hook_test.go
@@ -192,6 +192,51 @@ func TestHookDoesNotAcceptProfileFlag(t *testing.T) {
 	}
 }
 
+func TestHookFullContentWritesRedactedEvent(t *testing.T) {
+	outFile := filepath.Join(t.TempDir(), "records.ndjson")
+	secret := "sk-abcdefghijklmnopqrstuvwxyz0123456789"
+	prompt := strings.Repeat("ordinary context ", 20) + secret
+	payload, err := json.Marshal(map[string]any{
+		"hookEventName": "UserPromptSubmitted",
+		"prompt":        prompt,
+		"cwd":           "/proj",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, stderr, code := runCLIStdin(string(payload), "hook", "UserPromptSubmitted",
+		"--agent", "copilot", "--emit", "events", "--content", "full",
+		"--output", "file", "--output-file", outFile)
+	if code != 0 || strings.TrimSpace(stdout) != "{}" {
+		t.Fatalf("exit=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ev model.Event
+	if err := json.Unmarshal(bytes.TrimSpace(data), &ev); err != nil {
+		t.Fatal(err)
+	}
+	if ev.EventType != model.EventPromptUser || ev.Content == "" || strings.Contains(ev.Content, secret) || ev.ContentBytes != len(prompt) {
+		t.Fatalf("hook event content = %+v", ev)
+	}
+}
+
+func TestHookInstallWiresFullContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	_, errb, code := runCLI("hook", "install", "--agent", "claude", "--settings", path,
+		"--emit", "events", "--content", "full")
+	if code != 0 {
+		t.Fatalf("install exit = %d, stderr=%q", code, errb)
+	}
+	for _, command := range claudeInstalledCommands(t, path) {
+		if !strings.Contains(command, "--content=full") {
+			t.Fatalf("installed command missing full-content option: %q", command)
+		}
+	}
+}
+
 // A finding produced by a hook event is written to the configured sink, not to
 // stdout (stdout is reserved for the passthrough the agent reads). With
 // --output=file the secrets rule fires on `cat .env` and the finding lands in

--- a/cmd/numbat/scan.go
+++ b/cmd/numbat/scan.go
@@ -37,6 +37,7 @@ func runScan(args []string, stdout, stderr io.Writer) int {
 	fs.Var(&emitValues, "emit", emitFlagHelp())
 	contentFlag := fs.String("content", "preview", contentFlagHelp())
 	includeReasoning := fs.Bool("include-reasoning", false, "include source-recorded reasoning events")
+	profileFlag := fs.String("profile", "", "deprecated capture profile: evidence|full (full enables --include-reasoning)")
 	var outputValues multiFlag
 	fs.Var(&outputValues, "output", outputFlagHelp(outputModeStdout))
 	outputFile := fs.String("output-file", "", "destination path (required when --output includes file)")
@@ -88,6 +89,12 @@ func runScan(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	content, err := parseContentMode(*contentFlag)
+	if err != nil {
+		fmt.Fprintf(stderr, "scan: %v\n", err)
+		fs.Usage()
+		return 2
+	}
+	reasoning, err := applyDeprecatedProfile(*profileFlag, *includeReasoning)
 	if err != nil {
 		fmt.Fprintf(stderr, "scan: %v\n", err)
 		fs.Usage()
@@ -177,7 +184,7 @@ func runScan(args []string, stdout, stderr io.Writer) int {
 		emit:             em,
 		caseID:           *caseID,
 		sel:              sel,
-		includeReasoning: *includeReasoning,
+		includeReasoning: reasoning,
 		captureContent:   captureContent,
 	}
 	if sel.indicators {

--- a/cmd/numbat/scan.go
+++ b/cmd/numbat/scan.go
@@ -35,7 +35,8 @@ func runScan(args []string, stdout, stderr io.Writer) int {
 	caseID := fs.String("case-id", "", "case identifier stamped on every emitted event and derived finding")
 	var emitValues multiFlag
 	fs.Var(&emitValues, "emit", emitFlagHelp())
-	profileFlag := fs.String("profile", string(extract.ProfileEvidence), "capture depth: evidence (no reasoning/model context)|full")
+	contentFlag := fs.String("content", "preview", contentFlagHelp())
+	includeReasoning := fs.Bool("include-reasoning", false, "include source-recorded reasoning events")
 	var outputValues multiFlag
 	fs.Var(&outputValues, "output", outputFlagHelp(outputModeStdout))
 	outputFile := fs.String("output-file", "", "destination path (required when --output includes file)")
@@ -50,7 +51,7 @@ func runScan(args []string, stdout, stderr io.Writer) int {
 	var rf ruleFlags
 	rf.register(fs)
 	fs.Usage = func() {
-		fmt.Fprintln(stderr, "usage: numbat scan [--agent NAME ... | --path FILE|DIR ...] [--case-id ID] [--emit KIND ...] [--profile evidence|full] [--rules-dir DIR ...] [--no-builtin-rules] [--output SINK ...]")
+		fmt.Fprintln(stderr, "usage: numbat scan [--agent NAME ... | --path FILE|DIR ...] [--case-id ID] [--emit KIND ...] [--content preview|full] [--include-reasoning] [--rules-dir DIR ...] [--no-builtin-rules] [--output SINK ...]")
 		fmt.Fprintln(stderr, "\nScans supported on-disk agent artifacts and emits redacted findings, events, or indicators as NDJSON.")
 		fmt.Fprintf(stderr, "Automatic-discovery agents: %s.\n", artifactAgentUsage())
 		fmt.Fprintln(stderr, "Preserve vendor directory layouts when scanning copied or mounted artifacts.")
@@ -86,8 +87,13 @@ func runScan(args []string, stdout, stderr io.Writer) int {
 		fs.Usage()
 		return 2
 	}
-	profile, err := parseProfile(*profileFlag)
+	content, err := parseContentMode(*contentFlag)
 	if err != nil {
+		fmt.Fprintf(stderr, "scan: %v\n", err)
+		fs.Usage()
+		return 2
+	}
+	if err := validateContentSelection(content, sel); err != nil {
 		fmt.Fprintf(stderr, "scan: %v\n", err)
 		fs.Usage()
 		return 2
@@ -99,7 +105,7 @@ func runScan(args []string, stdout, stderr io.Writer) int {
 	}
 
 	// Resolve the output sink up front. A bad output/auth combination is a CLI
-	// error (like --emit/--profile above): it returns 2 without a scan_summary,
+	// error (like --emit/--content above): it returns 2 without a scan_summary,
 	// because no scan was attempted. stdout is the default sink and wraps the
 	// provided writer without taking ownership of it.
 	// Collect the http-only flags the operator actually passed, so buildSink can
@@ -133,7 +139,7 @@ func runScan(args []string, stdout, stderr io.Writer) int {
 	}
 
 	// Runtime failures get a summary; usage errors above do not start a scan.
-	em := output.NewWithSink(sink, stderr, runID())
+	em := output.NewWithSink(sink, stderr, runID(), contentEmitterOptions(content)...)
 
 	roots := []string(paths)
 	if len(roots) == 0 {
@@ -165,9 +171,15 @@ func runScan(args []string, stdout, stderr io.Writer) int {
 			return failScan(em, err.Error())
 		}
 	}
-	captureContent := sel.indicators || sel.findings && eng != nil && eng.UsesContent()
+	captureContent := content == contentFull || sel.indicators || sel.findings && eng != nil && eng.UsesContent()
 
-	sc := &scanner{emit: em, caseID: *caseID, sel: sel, profile: profile, captureContent: captureContent}
+	sc := &scanner{
+		emit:             em,
+		caseID:           *caseID,
+		sel:              sel,
+		includeReasoning: *includeReasoning,
+		captureContent:   captureContent,
+	}
 	if sel.indicators {
 		sc.indicators = output.NewIndicatorAccumulator()
 	}
@@ -427,31 +439,17 @@ func (s emitSelection) defaultFindingsOnly() bool {
 	return s.findings && !s.events && !s.indicators
 }
 
-// parseProfile validates the --profile flag and maps it onto an extract.Profile.
-// The default (evidence) yields only forensic evidence; full additionally yields
-// model reasoning and session-context join keys.
-func parseProfile(v string) (extract.Profile, error) {
-	switch extract.Profile(v) {
-	case extract.ProfileEvidence:
-		return extract.ProfileEvidence, nil
-	case extract.ProfileFull:
-		return extract.ProfileFull, nil
-	default:
-		return "", fmt.Errorf("invalid --profile %q: want evidence|full", v)
-	}
-}
-
 // scanner holds per-run artifact-processing state.
 type scanner struct {
-	emit           *output.Emitter
-	caseID         string
-	sel            emitSelection
-	profile        extract.Profile
-	captureContent bool
-	pipe           *pipeline.Pipeline
-	indicators     *output.IndicatorAccumulator
-	parsed         int
-	failed         int
+	emit             *output.Emitter
+	caseID           string
+	sel              emitSelection
+	includeReasoning bool
+	captureContent   bool
+	pipe             *pipeline.Pipeline
+	indicators       *output.IndicatorAccumulator
+	parsed           int
+	failed           int
 	// lookup is overridden only by tests.
 	lookup func(agent string) (extract.Extractor, bool)
 }
@@ -492,10 +490,10 @@ func (s *scanner) scanArtifact(a discover.Artifact) {
 	defer f.Close()
 
 	res, err := extract.SafeExtract(ex, f, extract.Source{
-		Path:           a.Path,
-		CaseID:         s.caseID,
-		Profile:        s.profile,
-		CaptureContent: s.captureContent,
+		Path:             a.Path,
+		CaseID:           s.caseID,
+		IncludeReasoning: s.includeReasoning,
+		CaptureContent:   s.captureContent,
 	})
 	if err != nil {
 		s.emit.Diag("error", fmt.Sprintf("parse %q: %v", a.Path, err))

--- a/cmd/numbat/scan_emit_test.go
+++ b/cmd/numbat/scan_emit_test.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/perplexityai/numbat/internal/model"
 )
 
 // recordTypes returns the record_type of every NDJSON line on stdout, in order.
@@ -33,6 +36,28 @@ func countType(types []string, want string) int {
 		}
 	}
 	return n
+}
+
+func decodeEventRecords(t *testing.T, out string) []model.Event {
+	t.Helper()
+	var events []model.Event
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		var envelope struct {
+			RecordType string `json:"record_type"`
+		}
+		if err := json.Unmarshal([]byte(line), &envelope); err != nil {
+			t.Fatal(err)
+		}
+		if envelope.RecordType != "event" {
+			continue
+		}
+		var ev model.Event
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatal(err)
+		}
+		events = append(events, ev)
+	}
+	return events
 }
 
 // scanSummary is the subset of the terminal scan_summary record the tests assert
@@ -75,7 +100,7 @@ func decodeSummary(t *testing.T, out string) scanSummary {
 
 // A transcript whose assistant turn thinks, fetches a URL, calls an MCP tool,
 // reads .env (fires the secrets rule) and cats it. Exercises events, findings,
-// indicators, and the evidence/full profile split in one fixture.
+// indicators, and optional reasoning in one fixture.
 const emitTranscript = `{"type":"user","uuid":"u1","sessionId":"s1","timestamp":"2026-06-02T10:00:00Z","cwd":"/home/dev/proj","message":{"role":"user","content":"read the env"}}
 {"type":"assistant","uuid":"a1","sessionId":"s1","timestamp":"2026-06-02T10:00:01Z","cwd":"/home/dev/proj","message":{"role":"assistant","content":[{"type":"thinking","thinking":"I will read the env file"},{"type":"tool_use","id":"t1","name":"Read","input":{"file_path":"/home/dev/proj/.env"}},{"type":"tool_use","id":"t2","name":"Bash","input":{"command":"cat .env"}},{"type":"tool_use","id":"t3","name":"WebFetch","input":{"url":"https://evil.example/x","prompt":"grab"}},{"type":"tool_use","id":"t4","name":"mcp__db__query","input":{"q":"SELECT 1"}}]}}`
 
@@ -244,41 +269,87 @@ func TestParseEmitRejectsAliases(t *testing.T) {
 	}
 }
 
-// The evidence profile (default) must NOT surface model reasoning: a
-// message.reasoning event is opt-in to the full profile only.
-func TestScanProfileEvidenceOmitsReasoning(t *testing.T) {
+// Reasoning is omitted unless explicitly requested.
+func TestScanOmitsReasoningByDefault(t *testing.T) {
 	p := writeTranscript(t, emitTranscript)
 	out, _, code := runCLI("scan", "--path", p, "--emit", "events")
 	if code != 0 {
 		t.Fatalf("exit = %d", code)
 	}
 	if strings.Contains(out, `"event_type":"message.reasoning"`) {
-		t.Errorf("evidence profile leaked reasoning:\n%s", out)
+		t.Errorf("default scan leaked reasoning:\n%s", out)
 	}
 }
 
-// The full profile surfaces model reasoning as a message.reasoning event.
-func TestScanProfileFullIncludesReasoning(t *testing.T) {
+func TestScanIncludeReasoning(t *testing.T) {
 	p := writeTranscript(t, emitTranscript)
-	out, _, code := runCLI("scan", "--path", p, "--emit", "events", "--profile", "full")
+	out, _, code := runCLI("scan", "--path", p, "--emit", "events", "--include-reasoning")
 	if code != 0 {
 		t.Fatalf("exit = %d", code)
 	}
 	if !strings.Contains(out, `"event_type":"message.reasoning"`) {
-		t.Errorf("full profile did not surface reasoning:\n%s", out)
+		t.Errorf("--include-reasoning did not surface reasoning:\n%s", out)
 	}
 }
 
-// An invalid --profile value is a usage error (exit 2).
-func TestScanProfileInvalidValue(t *testing.T) {
+func TestScanFullContentIsExplicitBoundedAndRedacted(t *testing.T) {
+	secret := "sk-abcdefghijklmnopqrstuvwxyz0123456789"
+	raw := strings.Repeat("ordinary context ", 20) + secret + "\nfinal line"
+	body := `{"type":"user","uuid":"u1","sessionId":"s1","message":{"role":"user","content":` + strconv.Quote(raw) + `}}`
+	p := writeTranscript(t, body)
+
+	previewOut, _, code := runCLI("scan", "--path", p, "--emit", "events")
+	if code != 0 {
+		t.Fatalf("preview exit = %d", code)
+	}
+	preview := decodeEventRecords(t, previewOut)
+	if len(preview) == 0 || preview[1].EventType != model.EventPromptUser {
+		t.Fatalf("preview events = %+v", preview)
+	}
+	if preview[1].Content != "" || !preview[1].ContentPreviewTruncated || strings.Contains(previewOut, secret) {
+		t.Fatalf("default projection exposed or misreported content:\n%s", previewOut)
+	}
+
+	fullOut, _, code := runCLI("scan", "--path", p, "--emit", "events", "--content", "full")
+	if code != 0 {
+		t.Fatalf("full exit = %d", code)
+	}
+	full := decodeEventRecords(t, fullOut)
+	if len(full) == 0 || full[1].EventType != model.EventPromptUser {
+		t.Fatalf("full events = %+v", full)
+	}
+	got := full[1]
+	if got.Content == "" || strings.Contains(got.Content, secret) || !strings.Contains(got.Content, "[redacted]") {
+		t.Fatalf("full content omitted or unredacted: %q", got.Content)
+	}
+	if got.ContentBytes != len(raw) || got.ContentTruncated {
+		t.Fatalf("content metadata = %d/%v, want %d/false", got.ContentBytes, got.ContentTruncated, len(raw))
+	}
+}
+
+func TestScanFullContentRequiresEvents(t *testing.T) {
 	p := writeTranscript(t, emitTranscript)
-	_, errb, code := runCLI("scan", "--path", p, "--profile", "bogus")
-	if code != 2 {
-		t.Fatalf("exit = %d, want 2", code)
+	_, errb, code := runCLI("scan", "--path", p, "--content", "full")
+	if code != 2 || !strings.Contains(errb, "--content full requires --emit events or --emit all") {
+		t.Fatalf("exit=%d stderr=%q", code, errb)
 	}
-	if !strings.Contains(errb, "invalid --profile") {
-		t.Errorf("stderr missing profile error: %q", errb)
+}
+
+func TestScanReasoningCanEmitFullContent(t *testing.T) {
+	p := writeTranscript(t, emitTranscript)
+	out, _, code := runCLI("scan", "--path", p, "--emit", "events", "--include-reasoning", "--content", "full")
+	if code != 0 {
+		t.Fatalf("exit = %d", code)
 	}
+	for _, ev := range decodeEventRecords(t, out) {
+		if ev.EventType == model.EventMessageReasoning {
+			if ev.Content != "I will read the env file" {
+				t.Fatalf("reasoning content = %q", ev.Content)
+			}
+			return
+		}
+	}
+	t.Fatal("reasoning event not emitted")
 }
 
 // --emit events surfaces the typed fields the new wiring populates: a WebFetch

--- a/cmd/numbat/scan_emit_test.go
+++ b/cmd/numbat/scan_emit_test.go
@@ -292,6 +292,42 @@ func TestScanIncludeReasoning(t *testing.T) {
 	}
 }
 
+func TestScanDeprecatedFullProfileIncludesReasoningOnly(t *testing.T) {
+	p := writeTranscript(t, emitTranscript)
+	out, _, code := runCLI("scan", "--path", p, "--emit", "events", "--profile", "full")
+	if code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	for _, ev := range decodeEventRecords(t, out) {
+		if ev.EventType != model.EventMessageReasoning {
+			continue
+		}
+		if ev.Content != "" {
+			t.Fatalf("deprecated --profile full emitted full content: %q", ev.Content)
+		}
+		return
+	}
+	t.Fatal("deprecated --profile full did not include reasoning")
+}
+
+func TestScanDeprecatedEvidenceProfileOmitsReasoning(t *testing.T) {
+	p := writeTranscript(t, emitTranscript)
+	out, _, code := runCLI("scan", "--path", p, "--emit", "events", "--profile", "evidence")
+	if code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if strings.Contains(out, `"event_type":"message.reasoning"`) {
+		t.Fatalf("deprecated --profile evidence included reasoning:\n%s", out)
+	}
+}
+
+func TestScanRejectsInvalidDeprecatedProfile(t *testing.T) {
+	_, errb, code := runCLI("scan", "--profile", "everything")
+	if code != 2 || !strings.Contains(errb, `invalid --profile "everything": want evidence|full`) {
+		t.Fatalf("exit=%d stderr=%q", code, errb)
+	}
+}
+
 func TestScanFullContentIsExplicitBoundedAndRedacted(t *testing.T) {
 	secret := "sk-abcdefghijklmnopqrstuvwxyz0123456789"
 	raw := strings.Repeat("ordinary context ", 20) + secret + "\nfinal line"

--- a/cmd/numbat/scan_test.go
+++ b/cmd/numbat/scan_test.go
@@ -551,9 +551,8 @@ func TestScanArtifactParsedFailedCounts(t *testing.T) {
 	var rec, diag bytes.Buffer
 	em := output.New(&rec, &diag, "run-test")
 	sc := &scanner{
-		emit:    em,
-		sel:     emitSelection{events: true},
-		profile: "evidence",
+		emit: em,
+		sel:  emitSelection{events: true},
 	}
 	sc.pipe = newTestScannerPipeline(sc, em, time.Unix(0, 0))
 	// A discovered artifact with no registered extractor: the no-extractor branch
@@ -647,7 +646,7 @@ func TestScanArtifactPanicIsSkippedScanContinues(t *testing.T) {
 
 	var rec, diag bytes.Buffer
 	em := output.New(&rec, &diag, "run-test")
-	sc := &scanner{emit: em, sel: emitSelection{events: true}, profile: "evidence"}
+	sc := &scanner{emit: em, sel: emitSelection{events: true}}
 	sc.pipe = newTestScannerPipeline(sc, em, time.Unix(0, 0))
 	// Route the panic agent to the panicking parser; everything else uses the real
 	// registry so the well-formed Claude artifact parses normally.
@@ -708,7 +707,7 @@ func TestScanArtifactPanicDuringEmitIsFailedNotParsed(t *testing.T) {
 	// The records sink panics when it sees the sentinel event, modeling a crash mid
 	// stream; all other records (the good artifact's) flow through to rec.
 	em := output.NewWithSink(panicSink{inner: &rec}, &diag, "run-test")
-	sc := &scanner{emit: em, sel: emitSelection{events: true}, profile: "evidence"}
+	sc := &scanner{emit: em, sel: emitSelection{events: true}}
 	sc.pipe = newTestScannerPipeline(sc, em, time.Unix(0, 0))
 	sc.lookup = func(agent string) (extract.Extractor, bool) {
 		if agent == "panic-emit-agent" {
@@ -754,7 +753,7 @@ func TestScanSummaryPartialStatusCountsParsedOnly(t *testing.T) {
 	good := writeTranscript(t, scanTranscript)
 	var rec, diag bytes.Buffer
 	em := output.New(&rec, &diag, "run-test")
-	sc := &scanner{emit: em, sel: emitSelection{events: true}, profile: "evidence"}
+	sc := &scanner{emit: em, sel: emitSelection{events: true}}
 	sc.pipe = newTestScannerPipeline(sc, em, time.Unix(0, 0))
 
 	sc.scanArtifact(discover.Artifact{Path: good, Agent: model.AgentClaudeCode})

--- a/cmd/numbat/timeline.go
+++ b/cmd/numbat/timeline.go
@@ -53,6 +53,7 @@ func runTimeline(args []string, stdout, stderr io.Writer) int {
 	caseID := fs.String("case-id", "", "case identifier stamped on every event")
 	contentFlag := fs.String("content", "preview", contentFlagHelp())
 	includeReasoning := fs.Bool("include-reasoning", false, "include source-recorded reasoning events")
+	profileFlag := fs.String("profile", "", "deprecated capture profile: evidence|full (full enables --include-reasoning)")
 	formatFlag := fs.String("format", timelineFormatText, "output format: text|json")
 	fs.Usage = func() {
 		fmt.Fprintln(stderr, "usage: numbat timeline [--agent NAME ... | --path FILE|DIR ...] [--case-id ID] [--include-reasoning] [--content preview|full] [--format text|json]")
@@ -91,6 +92,12 @@ func runTimeline(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	content, err := parseContentMode(*contentFlag)
+	if err != nil {
+		fmt.Fprintf(stderr, "timeline: %v\n", err)
+		fs.Usage()
+		return 2
+	}
+	reasoning, err := applyDeprecatedProfile(*profileFlag, *includeReasoning)
 	if err != nil {
 		fmt.Fprintf(stderr, "timeline: %v\n", err)
 		fs.Usage()
@@ -138,7 +145,7 @@ func runTimeline(args []string, stdout, stderr io.Writer) int {
 			}
 			seenArtifacts[key] = struct{}{}
 			discovered++
-			evs, ok := readArtifactEvents(a, *caseID, *includeReasoning, content == contentFull, stderr)
+			evs, ok := readArtifactEvents(a, *caseID, reasoning, content == contentFull, stderr)
 			if !ok {
 				continue
 			}

--- a/cmd/numbat/timeline.go
+++ b/cmd/numbat/timeline.go
@@ -38,10 +38,8 @@ var timelineExtractorFor = extract.For
 // It reuses scan's discovery model: --agent limits known default roots, while
 // repeatable --path reads explicit roots. It is tolerant the same way: a
 // per-file failure is a stderr diagnostic, not an abort.
-// Raw transcript content never leaves the box —
-// a step is anchored by its evidence ref (artifact path + line/pointer), and the
-// observed fields (command/path/url/content preview) are redacted on emission
-// (redact.Events, after grouping) before either view renders them.
+// The default view emits only redacted previews. JSON output can explicitly
+// include bounded, redacted conversation content with --content full.
 //
 // Exit codes: 0 on a completed render (even with no events), 2 on a usage error,
 // 1 when no artifact is found or every discovered artifact fails to parse.
@@ -53,10 +51,11 @@ func runTimeline(args []string, stdout, stderr io.Writer) int {
 	var agents multiFlag
 	fs.Var(&agents, "agent", "limit automatic discovery to a parser-backed agent (repeatable; cannot be combined with --path)")
 	caseID := fs.String("case-id", "", "case identifier stamped on every event")
-	profileFlag := fs.String("profile", string(extract.ProfileEvidence), "capture depth: evidence (no reasoning/model context)|full")
+	contentFlag := fs.String("content", "preview", contentFlagHelp())
+	includeReasoning := fs.Bool("include-reasoning", false, "include source-recorded reasoning events")
 	formatFlag := fs.String("format", timelineFormatText, "output format: text|json")
 	fs.Usage = func() {
-		fmt.Fprintln(stderr, "usage: numbat timeline [--agent NAME ... | --path FILE|DIR ...] [--case-id ID] [--profile evidence|full] [--format text|json]")
+		fmt.Fprintln(stderr, "usage: numbat timeline [--agent NAME ... | --path FILE|DIR ...] [--case-id ID] [--include-reasoning] [--content preview|full] [--format text|json]")
 		fmt.Fprintln(stderr, "\nReconstructs a per-session chronological view of agent activity (prompts, tool calls,")
 		fmt.Fprintln(stderr, "commands, approvals, file edits, outcomes) from the same artifacts scan reads.")
 		fmt.Fprintf(stderr, "Automatic-discovery agents: %s.\n", artifactAgentUsage())
@@ -91,13 +90,17 @@ func runTimeline(args []string, stdout, stderr io.Writer) int {
 		fs.Usage()
 		return 2
 	}
-	profile, err := parseProfile(*profileFlag)
+	content, err := parseContentMode(*contentFlag)
 	if err != nil {
 		fmt.Fprintf(stderr, "timeline: %v\n", err)
 		fs.Usage()
 		return 2
 	}
-
+	if content == contentFull && format != timelineFormatJSON {
+		fmt.Fprintln(stderr, "timeline: --content full requires --format json")
+		fs.Usage()
+		return 2
+	}
 	roots := []string(paths)
 	if len(roots) == 0 {
 		home, err := os.UserHomeDir()
@@ -135,7 +138,7 @@ func runTimeline(args []string, stdout, stderr io.Writer) int {
 			}
 			seenArtifacts[key] = struct{}{}
 			discovered++
-			evs, ok := readArtifactEvents(a, *caseID, profile, false, stderr)
+			evs, ok := readArtifactEvents(a, *caseID, *includeReasoning, content == contentFull, stderr)
 			if !ok {
 				continue
 			}
@@ -153,9 +156,13 @@ func runTimeline(args []string, stdout, stderr io.Writer) int {
 	}
 
 	sessions := groupSessions(events)
-	// Group first, then apply the shared event redactor before rendering.
+	// Group first, then apply the requested shared event projection.
 	for i := range sessions {
-		sessions[i].Events = redact.Events(sessions[i].Events)
+		if content == contentFull {
+			sessions[i].Events = redact.EventsWithContent(sessions[i].Events)
+		} else {
+			sessions[i].Events = redact.Events(sessions[i].Events)
+		}
 		sessions[i].ProjectPath = redact.String(sessions[i].ProjectPath)
 	}
 	if format == timelineFormatJSON {
@@ -172,7 +179,7 @@ func runTimeline(args []string, stdout, stderr io.Writer) int {
 // per-file tolerance: a missing extractor, an unreadable file, or a parse error
 // is a stderr diagnostic and yields ok=false so the caller skips it without
 // aborting the whole run. Per-line parse problems are diagnostics too.
-func readArtifactEvents(a discover.Artifact, caseID string, profile extract.Profile, captureContent bool, stderr io.Writer) ([]model.Event, bool) {
+func readArtifactEvents(a discover.Artifact, caseID string, includeReasoning, captureContent bool, stderr io.Writer) ([]model.Event, bool) {
 	ex, ok := timelineExtractorFor(a.Agent)
 	if !ok {
 		fmt.Fprintf(stderr, "timeline: no extractor for agent %q (%s)\n", a.Agent, a.Path)
@@ -186,10 +193,10 @@ func readArtifactEvents(a discover.Artifact, caseID string, profile extract.Prof
 	defer f.Close()
 
 	res, err := extract.SafeExtract(ex, f, extract.Source{
-		Path:           a.Path,
-		CaseID:         caseID,
-		Profile:        profile,
-		CaptureContent: captureContent,
+		Path:             a.Path,
+		CaseID:           caseID,
+		IncludeReasoning: includeReasoning,
+		CaptureContent:   captureContent,
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "timeline: parse %q: %v\n", a.Path, err)

--- a/cmd/numbat/timeline_panic_test.go
+++ b/cmd/numbat/timeline_panic_test.go
@@ -33,7 +33,7 @@ func TestTimelineReadArtifactRecoversFromParserPanic(t *testing.T) {
 	}
 
 	var stderr bytes.Buffer
-	evs, ok := readArtifactEvents(discover.Artifact{Path: p, Agent: "panic-agent"}, "", extract.ProfileEvidence, false, &stderr)
+	evs, ok := readArtifactEvents(discover.Artifact{Path: p, Agent: "panic-agent"}, "", false, false, &stderr)
 	if ok {
 		t.Fatal("a panicking parser must yield ok=false (skipped), not a clean read")
 	}

--- a/cmd/numbat/timeline_test.go
+++ b/cmd/numbat/timeline_test.go
@@ -153,6 +153,26 @@ func TestTimelineFullContentRequiresJSONAndIsExplicit(t *testing.T) {
 	t.Fatal("prompt event not found")
 }
 
+func TestTimelineDeprecatedFullProfileIncludesReasoning(t *testing.T) {
+	p := writeTranscript(t, emitTranscript)
+	out, errb, code := runCLI("timeline", "--path", p, "--format", "json", "--profile", "full")
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%q", code, errb)
+	}
+	var report timelineReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatal(err)
+	}
+	for _, session := range report.Sessions {
+		for _, ev := range session.Events {
+			if ev.EventType == model.EventMessageReasoning {
+				return
+			}
+		}
+	}
+	t.Fatal("deprecated --profile full did not include reasoning")
+}
+
 func TestTimelineOpenCodeKeepsSessionAndToolTimes(t *testing.T) {
 	root := t.TempDir()
 	p := filepath.Join(root, ".local", "share", "opencode", "storage", "part", "m1", "p1.json")

--- a/cmd/numbat/timeline_test.go
+++ b/cmd/numbat/timeline_test.go
@@ -125,6 +125,34 @@ func TestTimelineJSONShapeAndDeterminism(t *testing.T) {
 	}
 }
 
+func TestTimelineFullContentRequiresJSONAndIsExplicit(t *testing.T) {
+	p := writeTranscript(t, timelineTranscript)
+	_, errb, code := runCLI("timeline", "--path", p, "--content", "full")
+	if code != 2 || !strings.Contains(errb, "--content full requires --format json") {
+		t.Fatalf("text mode: exit=%d stderr=%q", code, errb)
+	}
+
+	out, errb, code := runCLI("timeline", "--path", p, "--format", "json", "--content", "full")
+	if code != 0 {
+		t.Fatalf("json mode: exit=%d stderr=%q", code, errb)
+	}
+	var report timelineReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatal(err)
+	}
+	for _, session := range report.Sessions {
+		for _, ev := range session.Events {
+			if ev.EventType == model.EventPromptUser {
+				if ev.Content != "read the env then build" || ev.ContentBytes != len(ev.Content) {
+					t.Fatalf("prompt content = %q bytes=%d", ev.Content, ev.ContentBytes)
+				}
+				return
+			}
+		}
+	}
+	t.Fatal("prompt event not found")
+}
+
 func TestTimelineOpenCodeKeepsSessionAndToolTimes(t *testing.T) {
 	root := t.TempDir()
 	p := filepath.Join(root, ".local", "share", "opencode", "storage", "part", "m1", "p1.json")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -95,8 +95,9 @@ agent's transcript.
 --case-id ID                 case identifier stamped on every emitted event and derived finding
 --emit KIND                  record kind to emit: findings, events, indicators,
                              or all (repeatable; default findings)
---profile evidence|full      capture depth; evidence omits reasoning/model context
-                             (default evidence)
+--content preview|full       conversation content in event output (default preview;
+                             full is redacted and bounded to 1 MiB)
+--include-reasoning          include source-recorded reasoning events
 --rules-dir DIR              operator rules to add or replace by id
                              (repeatable)
 --no-builtin-rules           load only --rules-dir rules
@@ -218,19 +219,22 @@ An indicator record (a `https://get.example.sh/install` URL seen twice):
 }
 ```
 
-### Capture profiles
+### Message content
 
-- `evidence` (default) — evidence-bearing events: prompts, assistant messages,
-  tool and command calls and their results (including `command.result` with an
-  exit code), file operations, config and MCP changes, network indicators, and
-  session lifecycle. It omits reasoning blocks and low-evidentiary model/session
-  context.
-- `full` — everything in `evidence` plus `message.reasoning` and model/provider
-  session context. Use it only when the additional context is required; it has
-  higher volume and sensitivity.
+Events contain a redacted `content_preview` of at most 200 Unicode code points
+by default. `--content full` adds bounded, redacted `content` to prompt,
+assistant, and reasoning events; it requires `--emit events` or `--emit all`.
+`content_bytes` is the mapped body size before the 1 MiB bound and output
+redaction, while `content_truncated` reports that Numbat applied the bound.
 
-`model`, `model_provider`, and `entrypoint` are source-specific and omitted when
-the source does not provide them; numbat does not infer these values.
+`--include-reasoning` adds reasoning summaries or thinking blocks that the
+source persisted. It does not recover hidden model chain-of-thought, and it is
+independent of `--content`: without `--content full`, reasoning events still
+carry only a preview. Rules and indicator extraction can inspect bounded
+message content without enabling full-content output.
+
+`model`, `model_provider`, and `entrypoint` are emitted when the source provides
+them; Numbat does not infer these values. Availability varies by agent.
 
 Finding `timestamp` is the matched event's activity time (the completing event
 for a sequence); `detected_at` is when numbat created the finding. `timestamp`
@@ -316,8 +320,9 @@ explicit-root `--path` modes as `scan`.
                              agent locations under $HOME plus supported
                              agent home/data env overrides)
 --case-id ID                 case identifier stamped on every event
---profile evidence|full      capture depth; evidence omits reasoning/model context
-                             (default evidence)
+--content preview|full       conversation content in JSON output (default preview;
+                             full is redacted and bounded to 1 MiB)
+--include-reasoning          include source-recorded reasoning events
 --format text|json           output format (default text)
 ```
 
@@ -325,7 +330,11 @@ explicit-root `--path` modes as `scan`.
 numbat timeline --agent claude
 numbat timeline --path ~/.claude/projects
 numbat timeline --path ~/.claude/projects --path ~/.codex --format json
+numbat timeline --agent codex --include-reasoning --content full --format json
 ```
+
+`--content full` is available only with `--format json`; the text view remains a
+compact preview.
 
 ## collect
 
@@ -360,6 +369,8 @@ IDs so receivers can deduplicate it.
 --case-id ID                 case identifier stamped on every emitted event and derived finding
 --emit KIND                  record kind to emit: findings, events, indicators,
                              or all (repeatable; default findings)
+--content preview|full       conversation content in event output (default preview;
+                             full is redacted and bounded to 1 MiB)
 --output SINK                record sink: stdout, file, or http
                              (repeatable; default stdout; stdout cannot be combined)
 --output-file PATH           destination path (required when output includes file)
@@ -536,6 +547,8 @@ below.
 --emit KIND                  record kind to emit: findings, events, indicators,
                              or all (repeatable; default findings; enforce mode
                              requires findings)
+--content preview|full       conversation content in event output (default preview;
+                             full is redacted and bounded to 1 MiB)
 --enforce                    opt-in enforce mode: block an action when a rule
                              marked enforce: true matches, including the final
                              action of a sequence. Off by default: monitor mode
@@ -603,6 +616,8 @@ default. This agent process deadline is separate from the hook handler's
                              findings, events, indicators, or all
                              (repeatable; default findings; enforce mode requires
                              findings)
+--content preview|full       conversation content installed hook commands emit
+                             (default preview; full requires events or all)
 --output SINK                record sink installed hook commands use:
                              stdout, file, or http (repeatable; default file;
                              stdout cannot be combined and writes records to

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -98,6 +98,7 @@ agent's transcript.
 --content preview|full       conversation content in event output (default preview;
                              full is redacted and bounded to 1 MiB)
 --include-reasoning          include source-recorded reasoning events
+--profile evidence|full      deprecated alias; full enables --include-reasoning
 --rules-dir DIR              operator rules to add or replace by id
                              (repeatable)
 --no-builtin-rules           load only --rules-dir rules
@@ -233,6 +234,9 @@ independent of `--content`: without `--content full`, reasoning events still
 carry only a preview. Rules and indicator extraction can inspect bounded
 message content without enabling full-content output.
 
+For compatibility, `scan` and `timeline` still accept `--profile`. Its `full`
+value enables `--include-reasoning`; it does not enable `--content full`.
+
 `model`, `model_provider`, and `entrypoint` are emitted when the source provides
 them; Numbat does not infer these values. Availability varies by agent.
 
@@ -323,6 +327,7 @@ explicit-root `--path` modes as `scan`.
 --content preview|full       conversation content in JSON output (default preview;
                              full is redacted and bounded to 1 MiB)
 --include-reasoning          include source-recorded reasoning events
+--profile evidence|full      deprecated alias; full enables --include-reasoning
 --format text|json           output format (default text)
 ```
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,8 +44,9 @@ enforce-capable pre-action callbacks. Join an
 response was delivered or honored by the host.
 
 Use `--emit all --output-file ~/.numbat/live.ndjson` when you want the complete
-live event stream. Use repeated `--output` flags when you also want a direct HTTP
-delivery attempt:
+live event stream. It uses conversation previews by default; add
+`--content full` only when bounded, redacted message text is required. Use
+repeated `--output` flags when you also want a direct HTTP delivery attempt:
 
 ```bash
 numbat hook install --agent claude \

--- a/docs/event-model.md
+++ b/docs/event-model.md
@@ -59,14 +59,18 @@ it does not mean success.
 
 Prompt, assistant, and source-recorded reasoning events carry a normalized
 `content_preview` of at most 200 Unicode code points. Rules and indicator
-extraction can inspect the source text through `content`, bounded to 1 MiB per
-event and reported by `content_bytes` and `content_truncated`. This applies only
-when the source exposes conversation text; it does not retain file bodies,
-patch text, or arbitrary tool output.
+extraction inspect mapped message text through `content`, bounded to 1 MiB per
+event.
+This analysis content is not emitted by default; `--content full` emits its
+redacted form with `content_bytes` and `content_truncated`.
+Reasoning is emitted only when the source exposes it and
+`--include-reasoning` is selected.
 
 `content_preview_truncated` states that the preview omits text. A long token is
-kept as a rune-safe prefix rather than disappearing. Output redaction runs
-after local rule evaluation.
+kept as a rune-safe prefix rather than disappearing. `content_bytes` counts the
+mapped body before Numbat's bound and output redaction. Message content does not
+include file bodies, patch text, or arbitrary tool output. Findings carry the
+same signal as `observed_content_preview_truncated`.
 
 ## MCP
 

--- a/docs/live-capture.md
+++ b/docs/live-capture.md
@@ -109,7 +109,9 @@ and applicable enforcement decisions to `$HOME/.numbat/findings.ndjson`. When
 events or indicators are selected, the default becomes
 `$HOME/.numbat/records.ndjson`. Change it with
 `--output-file PATH`; repeat `--emit findings|events|indicators`, or use
-`--emit all`. Repeat
+`--emit all`. Event records use bounded previews by default; add
+`--content full` to retain bounded, redacted conversation text when the agent
+exposes it. Repeat
 `--output file --output http --http-url URL` to keep the file and also attempt
 direct HTTP delivery. Direct HTTP alone is not durable: it has bounded in-memory
 buffering, but no disk spool. numbat does not rotate output files itself; for

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -175,12 +175,12 @@ That gate avoids matching both the request and result for sources that emit
 both. A custom rule may use only `command.exec` when it cares strictly about
 requested actions, or only `command.result` when completion matters.
 
-For conversation events, `event.content` is the unredacted, whitespace-
-preserving text numbat received, bounded to 1 MiB per event. It is independent
-of the 200-rune `event.content_preview`; use `event.content_truncated` when a
-rule must reject incomplete input. `event.content_bytes` is the number of bytes
-numbat received before applying its bound. These fields do not cause file
-bodies, patches, or arbitrary tool output to be retained.
+For conversation events, `event.content` is the unredacted mapped message text,
+bounded to 1 MiB per event. A rule that references a content field automatically
+enables this analysis; `--content full` is needed only to emit it. Use
+`event.content_truncated` when a rule must reject incomplete input.
+`event.content_bytes` is the mapped body size before Numbat's bound. These
+fields never include file bodies, patches, or arbitrary tool output.
 
 ### Event fields
 

--- a/docs/schema/v0.3.0/README.md
+++ b/docs/schema/v0.3.0/README.md
@@ -46,10 +46,10 @@ separators on every operating system so one rule works across platforms.
 Context fields such as `model`, `model_provider`, and `entrypoint` are
 source-specific and omitted when the source does not record them.
 
-Conversation events always use a bounded `content_preview`. Optional `content`,
-`content_bytes`, and truncation fields describe the fuller source text when the
-caller explicitly requests it; file bodies, patches, and arbitrary tool output
-are outside this contract.
+Conversation events always use a bounded `content_preview`. With
+`--content full`, optional `content`, `content_bytes`, and truncation fields
+describe bounded, redacted message text. File bodies, patches, and arbitrary
+tool output are outside this contract.
 
 On findings, `timestamp` is the matched event's activity time (the completing
 event for a sequence) and may be absent when that event has no valid timestamp.

--- a/docs/schema/v0.3.0/README.md
+++ b/docs/schema/v0.3.0/README.md
@@ -47,8 +47,9 @@ Context fields such as `model`, `model_provider`, and `entrypoint` are
 source-specific and omitted when the source does not record them.
 
 Conversation events always use a bounded `content_preview`. With
-`--content full`, optional `content`, `content_bytes`, and truncation fields
-describe bounded, redacted message text. File bodies, patches, and arbitrary
+`--content full`, `content` is redacted and bounded to 1 MiB. `content_bytes`
+records the mapped body size before that bound and output redaction, while
+`content_truncated` reports omitted bytes. File bodies, patches, and arbitrary
 tool output are outside this contract.
 
 On findings, `timestamp` is the matched event's activity time (the completing

--- a/docs/schema/v0.3.0/event-record.schema.json
+++ b/docs/schema/v0.3.0/event-record.schema.json
@@ -112,7 +112,11 @@
     "content_preview": { "type": "string", "maxLength": 200 },
     "content_preview_truncated": { "type": "boolean" },
     "content": { "type": "string", "minLength": 1 },
-    "content_bytes": { "type": "integer", "minimum": 1 },
+    "content_bytes": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Mapped message-body byte count before Numbat's 1 MiB bound and output redaction"
+    },
     "content_truncated": { "type": "boolean" },
     "tags": {
       "type": "array",

--- a/internal/archguard/archguard_test.go
+++ b/internal/archguard/archguard_test.go
@@ -207,7 +207,7 @@ func classifyCmdFile(name string) (forbidden []string, ok bool) {
 		name == "collect.go" || strings.HasPrefix(name, "collect_") ||
 		name == "ship.go" || strings.HasPrefix(name, "ship_"):
 		return forbidForensics, true
-	case name == "main.go" || name == "rules.go" || name == "rules_companion.go" ||
+	case name == "content.go" || name == "main.go" || name == "rules.go" || name == "rules_companion.go" ||
 		name == "run_id.go" || name == "sink.go" || name == "version.go":
 		return nil, true
 	case name == "agents.go":

--- a/internal/extract/claude.go
+++ b/internal/extract/claude.go
@@ -191,9 +191,7 @@ func (st *claudeState) observe(res *Result, e ClaudeExtractor, src Source, sha s
 		ev.Confidence = model.ConfidenceHigh
 		ev.GitBranch = entry.GitBranch
 		ev.CLIVersion = entry.Version
-		if src.fullProfile() {
-			ev.Model = entry.Message.Model
-		}
+		ev.Model = entry.Message.Model
 		st.startIdx = len(res.Events)
 		st.started = true
 		res.Events = append(res.Events, ev)
@@ -206,7 +204,7 @@ func (st *claudeState) observe(res *Result, e ClaudeExtractor, src Source, sha s
 	if start.CLIVersion == "" {
 		start.CLIVersion = entry.Version
 	}
-	if src.fullProfile() && start.Model == "" {
+	if start.Model == "" {
 		start.Model = entry.Message.Model
 	}
 }
@@ -277,7 +275,7 @@ func (e ClaudeExtractor) mapLine(res *Result, src Source, sha string, st *claude
 	case "user":
 		e.mapUser(res, src, sha, st, line, &entry)
 	case "assistant":
-		e.mapAssistant(res, src, sha, st, line, &entry, src.fullProfile())
+		e.mapAssistant(res, src, sha, st, line, &entry, src.IncludeReasoning)
 	case "permission-mode":
 		e.mapPermissionMode(res, src, sha, line, st, &entry, entry.PermissionMode, "/permissionMode")
 	case "mode":
@@ -403,7 +401,7 @@ func (e ClaudeExtractor) mapUser(res *Result, src Source, sha string, st *claude
 // several content blocks (text plus one or more tool_use calls); each becomes
 // its own event, in block order, so the emitted stream is a faithful timeline
 // and a tool call is a first-class, rule-matchable record.
-func (e ClaudeExtractor) mapAssistant(res *Result, src Source, sha string, st *claudeState, line int, entry *claudeEntry, full bool) {
+func (e ClaudeExtractor) mapAssistant(res *Result, src Source, sha string, st *claudeState, line int, entry *claudeEntry, includeReasoning bool) {
 	for i := range entry.Message.Content {
 		c := &entry.Message.Content[i]
 		switch c.Type {
@@ -432,9 +430,9 @@ func (e ClaudeExtractor) mapAssistant(res *Result, src Source, sha string, st *c
 			res.Events = append(res.Events, ev)
 		case "thinking":
 			// Model reasoning is opt-in: it is not forensic evidence of an
-			// action, only context, so it surfaces solely under the full profile.
+			// action, only context, so it surfaces only when reasoning is requested.
 			s := strings.TrimSpace(c.Thinking)
-			if !full || s == "" {
+			if !includeReasoning || s == "" {
 				continue
 			}
 			ev := e.base(src, sha, line, entry, i)

--- a/internal/extract/claude_entry.go
+++ b/internal/extract/claude_entry.go
@@ -101,7 +101,7 @@ type claudeAttachment struct {
 // claudeMessage is the user/assistant message envelope. content is either a
 // plain string (simple user prompts) or an array of typed content blocks; the
 // custom unmarshaler normalizes both into Content. Model is the assistant
-// message's model id, a session join key surfaced under the full profile.
+// message's model id, a source-recorded session join key.
 type claudeMessage struct {
 	Role    string
 	Model   string

--- a/internal/extract/claude_test.go
+++ b/internal/extract/claude_test.go
@@ -1118,10 +1118,10 @@ func TestExtractClaudeUnknownEntryTypeWarns(t *testing.T) {
 	}
 }
 
-// extractFixtureProfile parses a transcript under an explicit capture profile.
-func extractFixtureProfile(t *testing.T, body string, p Profile) *Result {
+// extractFixtureWithReasoning parses a transcript with explicit reasoning inclusion.
+func extractFixtureWithReasoning(t *testing.T, body string, includeReasoning bool) *Result {
 	t.Helper()
-	res, err := ClaudeExtractor{}.Extract(strings.NewReader(body), Source{Path: "/cases/session.jsonl", CaseID: "case-1", Profile: p})
+	res, err := ClaudeExtractor{}.Extract(strings.NewReader(body), Source{Path: "/cases/session.jsonl", CaseID: "case-1", IncludeReasoning: includeReasoning})
 	if err != nil {
 		t.Fatalf("Extract returned error: %v", err)
 	}
@@ -1276,20 +1276,18 @@ func TestExtractClaudeMCPNameSplit(t *testing.T) {
 	}
 }
 
-// Model reasoning (a thinking block) is opt-in: it is context, not forensic
-// evidence of an action, so it surfaces only under the full profile. Under the
-// default evidence profile it must be absent.
-func TestExtractClaudeReasoningProfileGated(t *testing.T) {
+// Model reasoning (a thinking block) is opt-in context.
+func TestExtractClaudeReasoningIsOptIn(t *testing.T) {
 	line := `{"type":"assistant","uuid":"a1","sessionId":"s-1","message":{"role":"assistant","content":[{"type":"thinking","thinking":"plotting the next step"},{"type":"text","text":"done"}]}}`
 
-	evidence := activityEvents(extractFixtureProfile(t, line, ProfileEvidence).Events)
+	evidence := activityEvents(extractFixtureWithReasoning(t, line, false).Events)
 	for _, ev := range evidence {
 		if ev.EventType == model.EventMessageReasoning {
-			t.Errorf("evidence profile surfaced reasoning: %+v", ev)
+			t.Errorf("default extraction surfaced reasoning: %+v", ev)
 		}
 	}
 
-	full := activityEvents(extractFixtureProfile(t, line, ProfileFull).Events)
+	full := activityEvents(extractFixtureWithReasoning(t, line, true).Events)
 	var reasoning *model.Event
 	for i := range full {
 		if full[i].EventType == model.EventMessageReasoning {
@@ -1297,11 +1295,19 @@ func TestExtractClaudeReasoningProfileGated(t *testing.T) {
 		}
 	}
 	if reasoning == nil {
-		t.Fatalf("full profile did not surface reasoning: %s", dumpEvents(full))
+		t.Fatalf("reasoning option did not surface reasoning: %s", dumpEvents(full))
 		return
 	}
 	if reasoning.Actor != model.ActorAssistant || reasoning.ContentPreview != "plotting the next step" {
 		t.Errorf("reasoning event = %s/%q, want assistant/'plotting the next step'", reasoning.Actor, reasoning.ContentPreview)
+	}
+}
+
+func TestExtractClaudeIncludesRecordedModelByDefault(t *testing.T) {
+	line := `{"type":"assistant","uuid":"a1","sessionId":"s-1","message":{"model":"claude-sonnet","role":"assistant","content":[{"type":"text","text":"done"}]}}`
+	res := extractFixtureWithReasoning(t, line, false)
+	if len(res.Events) == 0 || res.Events[0].EventType != model.EventSessionStart || res.Events[0].Model != "claude-sonnet" {
+		t.Fatalf("session context = %s", dumpEvents(res.Events))
 	}
 }
 

--- a/internal/extract/codex.go
+++ b/internal/extract/codex.go
@@ -287,7 +287,7 @@ func (e CodexExtractor) mapLine(res *Result, src Source, sha string, st *codexSt
 	case codexTypeTurnContext:
 		e.applyTurnContext(st, rl.Payload)
 	case codexTypeResponseItem:
-		e.mapResponseItem(res, src, sha, st, line, rl.Timestamp, rl.Payload, src.fullProfile())
+		e.mapResponseItem(res, src, sha, st, line, rl.Timestamp, rl.Payload, src.IncludeReasoning)
 	case codexTypeEventMsg:
 		e.mapEventMsg(res, src, sha, st, line, rl.Timestamp, rl.Payload)
 	case codexTypeCompacted:
@@ -342,9 +342,7 @@ func (e CodexExtractor) applySessionMeta(res *Result, src Source, sha string, st
 	ev.Actor = model.ActorSystem
 	ev.Confidence = model.ConfidenceHigh
 	ev.CLIVersion = meta.CliVersion
-	if src.fullProfile() {
-		ev.ModelProvider = meta.ModelProvider
-	}
+	ev.ModelProvider = meta.ModelProvider
 	ev.Evidence.JSONPointer = "/payload"
 	st.startIdx = len(res.Events)
 	st.started = true
@@ -403,7 +401,7 @@ func (e CodexExtractor) applyTurnContext(st *codexState, payload json.RawMessage
 // that carry no distinct activity are handled per-variant; an unknown variant
 // falls through to a generic tool.call only when it looks like a tool call,
 // otherwise it is skipped quietly.
-func (e CodexExtractor) mapResponseItem(res *Result, src Source, sha string, st *codexState, line int, ts string, payload json.RawMessage, full bool) {
+func (e CodexExtractor) mapResponseItem(res *Result, src Source, sha string, st *codexState, line int, ts string, payload json.RawMessage, includeReasoning bool) {
 	var ri codexResponseItem
 	if err := json.Unmarshal(payload, &ri); err != nil {
 		res.diag(src.Path, line, "malformed response_item payload")
@@ -602,10 +600,10 @@ func (e CodexExtractor) mapResponseItem(res *Result, src Source, sha string, st 
 	case codexRIReasoning:
 		// Model reasoning is opt-in: it is context, not forensic evidence of an
 		// action (mirrors Claude's thinking-block handling), so it surfaces only
-		// under the full profile. The reasoning text lives in the summary array
+		// when reasoning is requested. The text lives in the summary array
 		// (ReasoningItemReasoningSummary in models.rs); an empty body yields
 		// nothing.
-		if !full {
+		if !includeReasoning {
 			break
 		}
 		text := strings.TrimSpace(decodeCodexReasoningText(ri.Summary, ri.Content))

--- a/internal/extract/codex_entry.go
+++ b/internal/extract/codex_entry.go
@@ -185,7 +185,7 @@ type codexResponseItem struct {
 	// Reasoning. The reasoning item's human-readable text is the summary array
 	// (ReasoningItemReasoningSummary: [{type:"summary_text", text}]). Older/raw
 	// shapes carry it under content instead, so both are accepted; the reasoning
-	// text is surfaced only under the full profile.
+	// text is surfaced only when reasoning is requested.
 	Summary json.RawMessage `json:"summary"`
 }
 

--- a/internal/extract/codex_test.go
+++ b/internal/extract/codex_test.go
@@ -1186,10 +1186,10 @@ func TestExtractCodexMetaAndTurnContextEmitNothing(t *testing.T) {
 	}
 }
 
-// extractCodexProfile parses a rollout under an explicit capture profile.
-func extractCodexProfile(t *testing.T, body string, p Profile) *Result {
+// extractCodexWithReasoning parses a rollout with explicit reasoning inclusion.
+func extractCodexWithReasoning(t *testing.T, body string, includeReasoning bool) *Result {
 	t.Helper()
-	res, err := CodexExtractor{}.Extract(strings.NewReader(body), Source{Path: "/cases/rollout.jsonl", CaseID: "case-1", Profile: p})
+	res, err := CodexExtractor{}.Extract(strings.NewReader(body), Source{Path: "/cases/rollout.jsonl", CaseID: "case-1", IncludeReasoning: includeReasoning})
 	if err != nil {
 		t.Fatalf("Extract returned error: %v", err)
 	}
@@ -1405,20 +1405,19 @@ func TestExtractCodexCustomToolCallNamespaceFallback(t *testing.T) {
 	}
 }
 
-// Model reasoning is opt-in: a response_item reasoning item surfaces only under
-// the full profile. Under the default evidence profile it is absent.
-func TestExtractCodexReasoningProfileGated(t *testing.T) {
+// Model reasoning is opt-in context.
+func TestExtractCodexReasoningIsOptIn(t *testing.T) {
 	line := `{"timestamp":"t","type":"session_meta","payload":{"id":"s","cwd":"/p"}}
 {"timestamp":"t","type":"response_item","payload":{"type":"reasoning","summary":[{"type":"summary_text","text":"plotting the next step"}]}}`
 
-	evidence := activityEvents(extractCodexProfile(t, line, ProfileEvidence).Events)
+	evidence := activityEvents(extractCodexWithReasoning(t, line, false).Events)
 	for _, ev := range evidence {
 		if ev.EventType == model.EventMessageReasoning {
-			t.Errorf("evidence profile surfaced reasoning: %+v", ev)
+			t.Errorf("default extraction surfaced reasoning: %+v", ev)
 		}
 	}
 
-	full := activityEvents(extractCodexProfile(t, line, ProfileFull).Events)
+	full := activityEvents(extractCodexWithReasoning(t, line, true).Events)
 	var reasoning *model.Event
 	for i := range full {
 		if full[i].EventType == model.EventMessageReasoning {
@@ -1426,7 +1425,7 @@ func TestExtractCodexReasoningProfileGated(t *testing.T) {
 		}
 	}
 	if reasoning == nil {
-		t.Fatalf("full profile did not surface reasoning: %s", dumpEvents(full))
+		t.Fatalf("reasoning option did not surface reasoning: %s", dumpEvents(full))
 		return
 	}
 	if reasoning.Actor != model.ActorAssistant || reasoning.ContentPreview != "plotting the next step" {
@@ -1434,13 +1433,21 @@ func TestExtractCodexReasoningProfileGated(t *testing.T) {
 	}
 }
 
+func TestExtractCodexIncludesRecordedModelProviderByDefault(t *testing.T) {
+	line := `{"timestamp":"2026-06-02T10:00:00Z","type":"session_meta","payload":{"id":"s","cwd":"/p","model_provider":"openai"}}`
+	res := extractCodexWithReasoning(t, line, false)
+	if len(res.Events) == 0 || res.Events[0].EventType != model.EventSessionStart || res.Events[0].ModelProvider != "openai" {
+		t.Fatalf("session context = %s", dumpEvents(res.Events))
+	}
+}
+
 // Empty/encrypted reasoning carries no human-readable evidence. It is a
-// recognized no-op, including under the full profile, not a parse diagnostic.
+// recognized no-op even when reasoning is requested, not a parse diagnostic.
 func TestExtractCodexEncryptedReasoningNoOp(t *testing.T) {
 	line := `{"timestamp":"t","type":"session_meta","payload":{"id":"s","cwd":"/p"}}
 {"timestamp":"t","type":"response_item","payload":{"type":"reasoning","summary":[],"encrypted_content":"opaque"}}`
 
-	res := extractCodexProfile(t, line, ProfileFull)
+	res := extractCodexWithReasoning(t, line, true)
 	if len(res.Diagnostics) != 0 {
 		t.Fatalf("unexpected diagnostics: %+v", res.Diagnostics)
 	}

--- a/internal/extract/contract_test.go
+++ b/internal/extract/contract_test.go
@@ -11,17 +11,17 @@ import (
 // asserts each emitted event passes model.Event.Validate(). This is the proof
 // that the event_type→field co-occurrence contract (model.eventFields) matches
 // what the parsers actually emit: if a parser sets a value-bearing field the
-// contract does not allow for that event_type, Validate fails here. The full
-// profile is used so reasoning and session-context fields are exercised too.
+// contract does not allow for that event_type, Validate fails here. Reasoning
+// is included so its event shape is exercised too.
 //
 // If this fails, the allow-list is wrong — fix model.eventFields to match real
 // parser output; never loosen Validate to a no-op.
 func TestEmittedEventsSatisfyContract(t *testing.T) {
-	pi, err := (PiExtractor{}).Extract(strings.NewReader(piSessionFixture), Source{Profile: ProfileFull})
+	pi, err := (PiExtractor{}).Extract(strings.NewReader(piSessionFixture), Source{IncludeReasoning: true})
 	if err != nil {
 		t.Fatalf("extract Pi fixture: %v", err)
 	}
-	kimi, err := (KimiCodeExtractor{}).Extract(strings.NewReader(kimiWireFixture), Source{Profile: ProfileFull})
+	kimi, err := (KimiCodeExtractor{}).Extract(strings.NewReader(kimiWireFixture), Source{IncludeReasoning: true})
 	if err != nil {
 		t.Fatalf("extract Kimi fixture: %v", err)
 	}
@@ -31,15 +31,15 @@ func TestEmittedEventsSatisfyContract(t *testing.T) {
 		agent  string
 		events []model.Event
 	}{
-		{"claude", model.AgentClaudeCode, extractFixtureProfile(t, claudeFixture, ProfileFull).Events},
-		{"cowork", model.AgentCowork, extractCowork(t, coworkFixture, ProfileFull).Events},
-		{"codex", model.AgentCodex, extractCodexProfile(t, codexFixture, ProfileFull).Events},
+		{"claude", model.AgentClaudeCode, extractFixtureWithReasoning(t, claudeFixture, true).Events},
+		{"cowork", model.AgentCowork, extractCowork(t, coworkFixture, true).Events},
+		{"codex", model.AgentCodex, extractCodexWithReasoning(t, codexFixture, true).Events},
 		{"gemini", model.AgentGeminiCLI, extractGemini(t, geminiArrayFixture).Events},
-		{"gemini-session", model.AgentGeminiCLI, extractGeminiSession(t, geminiSessionFixture, ProfileFull).Events},
-		{"cursor", model.AgentCursor, extractCursor(t, cursorFixture, ProfileFull).Events},
-		{"windsurf", model.AgentWindsurf, extractWindsurf(t, windsurfFixture, ProfileFull).Events},
-		{"copilot", model.AgentCopilot, extractCopilot(t, copilotFixture, ProfileFull).Events},
-		{"opencode", model.AgentOpenCode, extractOpenCodeProfile(t, `{"type":"tool","callID":"c1","tool":"bash","state":{"status":"error","input":{"command":"go test ./..."},"error":"tests failed"}}`, ProfileFull).Events},
+		{"gemini-session", model.AgentGeminiCLI, extractGeminiSession(t, geminiSessionFixture, true).Events},
+		{"cursor", model.AgentCursor, extractCursor(t, cursorFixture).Events},
+		{"windsurf", model.AgentWindsurf, extractWindsurf(t, windsurfFixture).Events},
+		{"copilot", model.AgentCopilot, extractCopilot(t, copilotFixture).Events},
+		{"opencode", model.AgentOpenCode, extractOpenCodeWithReasoning(t, `{"type":"tool","callID":"c1","tool":"bash","state":{"status":"error","input":{"command":"go test ./..."},"error":"tests failed"}}`, true).Events},
 		{"openclaw", model.AgentOpenClaw, extractOpenClaw(t, withHeader(`{"type":"message","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"go test ./..."}}]}}`)).Events},
 		{"pi", model.AgentPi, pi.Events},
 		{"kimi-code", model.AgentKimiCode, kimi.Events},

--- a/internal/extract/copilot_test.go
+++ b/internal/extract/copilot_test.go
@@ -18,9 +18,9 @@ const copilotFixture = `{"type":"UserPromptSubmitted","id":"cu1","sessionId":"se
 {"hookEventName":"PreToolUse","id":"ct1","sessionId":"sess-1","timestamp":"2026-06-03T10:00:02Z","cwd":"/home/dev/proj","toolName":"ShellCommand","toolCallId":"t1","toolArgs":"{\"command\":\"go test ./...\"}"}
 {"hookEventName":"PostToolUse","id":"ct1r","sessionId":"sess-1","timestamp":"2026-06-03T10:00:03Z","cwd":"/home/dev/proj","toolName":"ShellCommand","toolCallId":"t1","exitCode":1,"error":"tests failed"}`
 
-func extractCopilot(t *testing.T, body string, profile Profile) *Result {
+func extractCopilot(t *testing.T, body string) *Result {
 	t.Helper()
-	res, err := CopilotExtractor{}.Extract(strings.NewReader(body), Source{Path: "/cases/copilot.jsonl", CaseID: "case-cp", Profile: profile})
+	res, err := CopilotExtractor{}.Extract(strings.NewReader(body), Source{Path: "/cases/copilot.jsonl", CaseID: "case-cp"})
 	if err != nil {
 		t.Fatalf("Extract returned error: %v", err)
 	}
@@ -32,7 +32,7 @@ func extractCopilot(t *testing.T, body string, profile Profile) *Result {
 // code — every event stamped with the copilot source identity and the copilot
 // artifact type. This is the headline correlation+exit-code proof.
 func TestExtractCopilotMapsShapesWithCopilotIdentity(t *testing.T) {
-	res := extractCopilot(t, copilotFixture, ProfileEvidence)
+	res := extractCopilot(t, copilotFixture)
 	if len(res.Diagnostics) != 0 {
 		t.Fatalf("unexpected diagnostics: %+v", res.Diagnostics)
 	}
@@ -116,7 +116,7 @@ func TestExtractCopilotMapsShapesWithCopilotIdentity(t *testing.T) {
 // TestExtractCopilotMapsShapesWithCopilotIdentity.
 func TestExtractCopilotOrphanResultStaysToolResult(t *testing.T) {
 	const body = `{"hookEventName":"PostToolUse","id":"x","sessionId":"c","toolName":"ShellCommand","toolCallId":"orphan","exitCode":0}`
-	res := extractCopilot(t, body, ProfileEvidence)
+	res := extractCopilot(t, body)
 	acts := activityEvents(res.Events)
 	if len(acts) != 1 {
 		t.Fatalf("got %d activity events, want 1:\n%s", len(acts), dumpEvents(res.Events))
@@ -135,7 +135,7 @@ func TestExtractCopilotOrphanResultStaysToolResult(t *testing.T) {
 func TestExtractCopilotNonCommandResultAndError(t *testing.T) {
 	const body = `{"hookEventName":"PreToolUse","id":"a","sessionId":"c","toolName":"ReadFile","toolCallId":"r1","toolArgs":"{\"path\":\"/etc/hosts\"}"}
 {"hookEventName":"PostToolUse","id":"b","sessionId":"c","toolName":"ReadFile","toolCallId":"r1","isError":true}`
-	res := extractCopilot(t, body, ProfileEvidence)
+	res := extractCopilot(t, body)
 	acts := activityEvents(res.Events)
 	if len(acts) != 2 {
 		t.Fatalf("got %d activity events, want 2:\n%s", len(acts), dumpEvents(res.Events))
@@ -155,7 +155,7 @@ func TestExtractCopilotNonCommandResultAndError(t *testing.T) {
 // policy mirrored from the live hook.
 func TestExtractCopilotReadNeverStoresContent(t *testing.T) {
 	const body = `{"hookEventName":"PreToolUse","id":"a","sessionId":"c","toolName":"ReadFile","toolArgs":"{\"path\":\"/proj/.env\",\"content\":\"SECRET=abc\"}"}`
-	res := extractCopilot(t, body, ProfileEvidence)
+	res := extractCopilot(t, body)
 	acts := activityEvents(res.Events)
 	if len(acts) != 1 {
 		t.Fatalf("got %d activity events, want 1:\n%s", len(acts), dumpEvents(res.Events))
@@ -173,7 +173,7 @@ func TestExtractCopilotReadNeverStoresContent(t *testing.T) {
 func TestExtractCopilotNetworkIndicator(t *testing.T) {
 	t.Run("web_fetch", func(t *testing.T) {
 		const body = `{"hookEventName":"PreToolUse","id":"a","sessionId":"c","toolName":"WebFetch","toolArgs":"{\"url\":\"https://example.com/x\"}"}`
-		acts := activityEvents(extractCopilot(t, body, ProfileEvidence).Events)
+		acts := activityEvents(extractCopilot(t, body).Events)
 		if len(acts) != 1 {
 			t.Fatalf("got %d activity events, want 1:\n%s", len(acts), dumpEvents(acts))
 		}
@@ -187,7 +187,7 @@ func TestExtractCopilotNetworkIndicator(t *testing.T) {
 	})
 	t.Run("web_search", func(t *testing.T) {
 		const body = `{"hookEventName":"PreToolUse","id":"a","sessionId":"c","toolName":"WebSearch","toolArgs":"{\"query\":\"how to exfiltrate\"}"}`
-		acts := activityEvents(extractCopilot(t, body, ProfileEvidence).Events)
+		acts := activityEvents(extractCopilot(t, body).Events)
 		if len(acts) != 1 {
 			t.Fatalf("got %d activity events, want 1:\n%s", len(acts), dumpEvents(acts))
 		}
@@ -208,7 +208,7 @@ func TestExtractCopilotNetworkIndicator(t *testing.T) {
 	t.Run("web_fetch_rejects_non_http", func(t *testing.T) {
 		const bad = "file:///etc/passwd"
 		const body = `{"hookEventName":"PreToolUse","id":"a","sessionId":"c","toolName":"WebFetch","toolArgs":"{\"url\":\"file:///etc/passwd\"}"}`
-		acts := activityEvents(extractCopilot(t, body, ProfileEvidence).Events)
+		acts := activityEvents(extractCopilot(t, body).Events)
 		if len(acts) != 1 {
 			t.Fatalf("got %d activity events, want 1:\n%s", len(acts), dumpEvents(acts))
 		}
@@ -232,7 +232,7 @@ func TestExtractCopilotNetworkIndicator(t *testing.T) {
 // branch of the classifier's tool.call fallback.
 func TestExtractCopilotMCPSplit(t *testing.T) {
 	const body = `{"hookEventName":"PreToolUse","id":"a","sessionId":"c","toolName":"mcp__github__create_issue","toolArgs":"{\"title\":\"x\"}"}`
-	acts := activityEvents(extractCopilot(t, body, ProfileEvidence).Events)
+	acts := activityEvents(extractCopilot(t, body).Events)
 	if len(acts) != 1 || acts[0].EventType != model.EventToolCall {
 		t.Fatalf("got %d events / type %s, want one tool.call:\n%s", len(acts), acts[0].EventType, dumpEvents(acts))
 	}
@@ -264,7 +264,7 @@ func TestExtractCopilotUnknownToolFallsBackToToolCall(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			body := `{"hookEventName":"PreToolUse","id":"a","sessionId":"c","toolName":"` + name + `","toolArgs":"{\"command\":\"x\",\"path\":\"/p\",\"url\":\"https://e/x\"}"}`
-			acts := activityEvents(extractCopilot(t, body, ProfileEvidence).Events)
+			acts := activityEvents(extractCopilot(t, body).Events)
 			if len(acts) != 1 {
 				t.Fatalf("got %d activity events, want 1:\n%s", len(acts), dumpEvents(acts))
 			}
@@ -293,7 +293,7 @@ func TestExtractCopilotIgnoresGenericArgKeys(t *testing.T) {
 	for _, key := range []string{"input", "args", "toolInput"} {
 		t.Run(key, func(t *testing.T) {
 			body := `{"hookEventName":"PreToolUse","id":"a","sessionId":"c","toolName":"ShellCommand","` + key + `":{"command":"cat .env"}}`
-			acts := activityEvents(extractCopilot(t, body, ProfileEvidence).Events)
+			acts := activityEvents(extractCopilot(t, body).Events)
 			if len(acts) != 1 || acts[0].EventType != model.EventCommandExec {
 				t.Fatalf("got %+v, want one command.exec", acts)
 			}
@@ -312,7 +312,7 @@ func TestExtractCopilotIgnoresGenericArgKeys(t *testing.T) {
 func TestExtractCopilotNoFabricatedExitCode(t *testing.T) {
 	const body = `{"hookEventName":"PreToolUse","id":"a","sessionId":"c","toolName":"ShellCommand","toolCallId":"s1","toolArgs":"{\"command\":\"echo hi\"}"}
 {"hookEventName":"PostToolUse","id":"b","sessionId":"c","toolName":"ShellCommand","toolCallId":"s1"}`
-	acts := activityEvents(extractCopilot(t, body, ProfileEvidence).Events)
+	acts := activityEvents(extractCopilot(t, body).Events)
 	if len(acts) != 2 {
 		t.Fatalf("got %d activity events, want 2:\n%s", len(acts), dumpEvents(acts))
 	}
@@ -330,7 +330,7 @@ func TestExtractCopilotToleratesMalformedLine(t *testing.T) {
 	const body = `{"type":"UserPromptSubmitted","id":"u","sessionId":"c","prompt":"hello"}
 {not json}
 {"type":"assistant","id":"a","sessionId":"c","content":"hi"}`
-	res := extractCopilot(t, body, ProfileEvidence)
+	res := extractCopilot(t, body)
 	if len(res.Diagnostics) != 1 {
 		t.Fatalf("got %d diagnostics, want 1: %+v", len(res.Diagnostics), res.Diagnostics)
 	}
@@ -366,7 +366,7 @@ func TestExtractCopilotJSONPointersAreSourceFaithful(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			acts := activityEvents(extractCopilot(t, c.body, ProfileEvidence).Events)
+			acts := activityEvents(extractCopilot(t, c.body).Events)
 			if len(acts) != 1 {
 				t.Fatalf("got %d activity events, want 1:\n%s", len(acts), dumpEvents(acts))
 			}
@@ -390,7 +390,7 @@ func TestExtractCopilotToolArgsEncodingEquivalence(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			acts := activityEvents(extractCopilot(t, c.body, ProfileEvidence).Events)
+			acts := activityEvents(extractCopilot(t, c.body).Events)
 			if len(acts) != 1 || acts[0].EventType != model.EventCommandExec || acts[0].Command != "cat .env" {
 				t.Fatalf("got %+v, want one command.exec 'cat .env'", acts)
 			}
@@ -402,7 +402,7 @@ func TestExtractCopilotToolArgsEncodingEquivalence(t *testing.T) {
 // empty rather than panicking or fabricating a value.
 func TestExtractCopilotMalformedToolArgsDegradesSafely(t *testing.T) {
 	const body = `{"hookEventName":"PreToolUse","id":"a","sessionId":"c","toolName":"ShellCommand","toolArgs":"not json at all"}`
-	acts := activityEvents(extractCopilot(t, body, ProfileEvidence).Events)
+	acts := activityEvents(extractCopilot(t, body).Events)
 	if len(acts) != 1 || acts[0].EventType != model.EventCommandExec {
 		t.Fatalf("got %+v, want one command.exec", acts)
 	}

--- a/internal/extract/cowork_test.go
+++ b/internal/extract/cowork_test.go
@@ -15,9 +15,9 @@ const coworkFixture = `{"type":"user","uuid":"cu1","sessionId":"cw-1","timestamp
 {"type":"assistant","uuid":"ca1","sessionId":"cw-1","timestamp":"2026-06-03T09:00:01Z","cwd":"/home/dev/proj","message":{"role":"assistant","content":[{"type":"thinking","thinking":"I should run go test."},{"type":"tool_use","id":"ct1","name":"Bash","input":{"command":"go test ./..."}}]}}
 {"type":"user","uuid":"cu2","sessionId":"cw-1","timestamp":"2026-06-03T09:00:05Z","cwd":"/home/dev/proj","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"ct1","content":"ok"}]},"toolUseResult":{"stdout":"ok","exit_code":0}}`
 
-func extractCowork(t *testing.T, body string, profile Profile) *Result {
+func extractCowork(t *testing.T, body string, includeReasoning bool) *Result {
 	t.Helper()
-	res, err := CoworkExtractor{}.Extract(strings.NewReader(body), Source{Path: "/cases/audit.jsonl", CaseID: "case-cw", Profile: profile})
+	res, err := CoworkExtractor{}.Extract(strings.NewReader(body), Source{Path: "/cases/audit.jsonl", CaseID: "case-cw", IncludeReasoning: includeReasoning})
 	if err != nil {
 		t.Fatalf("Extract returned error: %v", err)
 	}
@@ -28,7 +28,7 @@ func extractCowork(t *testing.T, body string, profile Profile) *Result {
 // parser, but every event must carry the cowork source identity and the
 // cowork artifact type — never claude-code.
 func TestExtractCoworkMapsShapesWithCoworkIdentity(t *testing.T) {
-	res := extractCowork(t, coworkFixture, ProfileFull)
+	res := extractCowork(t, coworkFixture, true)
 	if len(res.Diagnostics) != 0 {
 		t.Fatalf("unexpected diagnostics: %+v", res.Diagnostics)
 	}
@@ -84,13 +84,12 @@ func TestExtractCoworkMapsShapesWithCoworkIdentity(t *testing.T) {
 	assertUniqueEventIDs(t, res.Events)
 }
 
-// The default (evidence) profile must withhold model reasoning, exactly as the
-// Claude core does, so the thinking block yields no event.
-func TestExtractCoworkEvidenceProfileDropsReasoning(t *testing.T) {
-	res := extractCowork(t, coworkFixture, ProfileEvidence)
+// Reasoning is omitted by default, exactly as in the Claude core.
+func TestExtractCoworkDefaultDropsReasoning(t *testing.T) {
+	res := extractCowork(t, coworkFixture, false)
 	for _, ev := range res.Events {
 		if ev.EventType == model.EventMessageReasoning {
-			t.Fatalf("reasoning event leaked under evidence profile: %+v", ev)
+			t.Fatalf("reasoning event leaked by default: %+v", ev)
 		}
 	}
 }

--- a/internal/extract/cursor.go
+++ b/internal/extract/cursor.go
@@ -268,7 +268,7 @@ func messageRole(kind string) (model.EventType, string, bool) {
 	case "assistant", "ai", "model":
 		// Cursor transcripts carry the model's prose, not a separate reasoning
 		// channel, so assistant text is forensic message content (high confidence),
-		// not gated behind the full profile the way Claude's thinking blocks are.
+		// not gated with model reasoning because this is an agent-generated note.
 		return model.EventMessageAssistant, model.ActorAssistant, true
 	default:
 		return "", "", false

--- a/internal/extract/cursor_test.go
+++ b/internal/extract/cursor_test.go
@@ -16,9 +16,9 @@ const cursorFixture = `{"type":"user","id":"cu1","conversationId":"cur-1","times
 {"type":"assistant","id":"ca1","conversationId":"cur-1","timestamp":"2026-06-03T10:00:01Z","cwd":"/home/dev/proj","content":[{"type":"text","text":"Let me search for it."},{"type":"tool_call","name":"Shell","callId":"t1","input":{"command":"grep -r authMiddleware src/"}}]}
 {"type":"tool","id":"ct1","conversationId":"cur-1","timestamp":"2026-06-03T10:00:02Z","cwd":"/home/dev/proj","toolResult":{"callId":"t1","exitCode":0}}`
 
-func extractCursor(t *testing.T, body string, profile Profile) *Result {
+func extractCursor(t *testing.T, body string) *Result {
 	t.Helper()
-	res, err := CursorExtractor{}.Extract(strings.NewReader(body), Source{Path: "/cases/transcript.jsonl", CaseID: "case-cur", Profile: profile})
+	res, err := CursorExtractor{}.Extract(strings.NewReader(body), Source{Path: "/cases/transcript.jsonl", CaseID: "case-cur"})
 	if err != nil {
 		t.Fatalf("Extract returned error: %v", err)
 	}
@@ -29,7 +29,7 @@ func extractCursor(t *testing.T, body string, profile Profile) *Result {
 // and the correlated command.result — every event stamped with the cursor
 // source identity and the cursor artifact type.
 func TestExtractCursorMapsShapesWithCursorIdentity(t *testing.T) {
-	res := extractCursor(t, cursorFixture, ProfileEvidence)
+	res := extractCursor(t, cursorFixture)
 	if len(res.Diagnostics) != 0 {
 		t.Fatalf("unexpected diagnostics: %+v", res.Diagnostics)
 	}
@@ -95,7 +95,7 @@ func TestExtractCursorCurrentMessageEnvelope(t *testing.T) {
 	const body = `{"role":"user","message":{"content":[{"type":"text","text":"inspect the readme"}]}}
 {"role":"assistant","message":{"content":[{"type":"text","text":"I will open it."},{"type":"tool_use","name":"Read","input":{"path":"/workspace/README.md"}}]}}
 {"type":"turn_ended","status":"success"}`
-	res := extractCursor(t, body, ProfileEvidence)
+	res := extractCursor(t, body)
 	if len(res.Diagnostics) != 0 {
 		t.Fatalf("unexpected diagnostics: %+v", res.Diagnostics)
 	}
@@ -127,7 +127,7 @@ func TestExtractCursorCurrentMessageEnvelope(t *testing.T) {
 }
 
 func TestExtractCursorToleratesNonObjectMessageEnvelope(t *testing.T) {
-	res := extractCursor(t, `{"type":"system","message":"bookkeeping"}`, ProfileEvidence)
+	res := extractCursor(t, `{"type":"system","message":"bookkeeping"}`)
 	if len(res.Diagnostics) != 0 || len(res.Events) != 0 {
 		t.Fatalf("scalar message produced output: events=%s diagnostics=%+v", dumpEvents(res.Events), res.Diagnostics)
 	}
@@ -135,7 +135,7 @@ func TestExtractCursorToleratesNonObjectMessageEnvelope(t *testing.T) {
 
 func TestExtractCursorDiagnosesMultipleContentBodies(t *testing.T) {
 	const body = `{"role":"assistant","content":"top-level text","message":{"content":[{"type":"tool_use","name":"Read","input":{"path":"/workspace/hidden.txt"}}]}}`
-	res := extractCursor(t, body, ProfileEvidence)
+	res := extractCursor(t, body)
 	if len(res.Diagnostics) != 1 || !strings.Contains(res.Diagnostics[0].Msg, "multiple content bodies") {
 		t.Fatalf("diagnostics = %+v, want one multiple-content warning", res.Diagnostics)
 	}
@@ -151,7 +151,7 @@ func TestExtractCursorDiagnosesMultipleContentBodies(t *testing.T) {
 func TestExtractCursorNonCommandResultAndError(t *testing.T) {
 	const body = `{"type":"assistant","id":"a","conversationId":"c","content":[{"type":"tool_call","name":"Read","callId":"r1","input":{"file_path":"/etc/hosts"}}]}
 {"type":"tool","id":"b","conversationId":"c","toolResult":{"callId":"r1","isError":true}}`
-	res := extractCursor(t, body, ProfileEvidence)
+	res := extractCursor(t, body)
 	acts := activityEvents(res.Events)
 	if len(acts) != 2 {
 		t.Fatalf("got %d activity events, want 2:\n%s", len(acts), dumpEvents(res.Events))
@@ -171,7 +171,7 @@ func TestExtractCursorNonCommandResultAndError(t *testing.T) {
 // network tag, mirroring the Claude classifier.
 func TestExtractCursorWebFetchNetworkIndicator(t *testing.T) {
 	const body = `{"type":"assistant","id":"a","conversationId":"c","content":[{"type":"tool_call","name":"web_fetch","callId":"w1","input":{"url":"https://example.com/x"}}]}`
-	res := extractCursor(t, body, ProfileEvidence)
+	res := extractCursor(t, body)
 	acts := activityEvents(res.Events)
 	if len(acts) != 1 {
 		t.Fatalf("got %d activity events, want 1:\n%s", len(acts), dumpEvents(res.Events))
@@ -191,7 +191,7 @@ func TestExtractCursorWebFetchNetworkIndicator(t *testing.T) {
 func TestExtractCursorWebFetchRejectsNonHTTPScheme(t *testing.T) {
 	const bad = "file:///etc/passwd"
 	const body = `{"type":"assistant","id":"a","conversationId":"c","content":[{"type":"tool_call","name":"web_fetch","callId":"w1","input":{"url":"file:///etc/passwd"}}]}`
-	acts := activityEvents(extractCursor(t, body, ProfileEvidence).Events)
+	acts := activityEvents(extractCursor(t, body).Events)
 	if len(acts) != 1 {
 		t.Fatalf("got %d activity events, want 1", len(acts))
 	}
@@ -216,7 +216,7 @@ func TestExtractCursorToleratesMalformedLine(t *testing.T) {
 	const body = `{"type":"user","id":"u","conversationId":"c","content":"hello"}
 {not json}
 {"type":"assistant","id":"a","conversationId":"c","content":"hi"}`
-	res := extractCursor(t, body, ProfileEvidence)
+	res := extractCursor(t, body)
 	if len(res.Diagnostics) != 1 {
 		t.Fatalf("got %d diagnostics, want 1: %+v", len(res.Diagnostics), res.Diagnostics)
 	}
@@ -233,7 +233,7 @@ func TestExtractCursorToleratesMalformedLine(t *testing.T) {
 // exit code and inverts the order.
 func TestExtractCursorSameRecordCommandCorrelation(t *testing.T) {
 	const body = `{"type":"assistant","id":"a","conversationId":"c","content":[{"type":"text","text":"running it"},{"type":"tool_call","name":"Shell","callId":"s1","input":{"command":"go test ./..."}},{"type":"tool_result","callId":"s1","exitCode":2}]}`
-	res := extractCursor(t, body, ProfileEvidence)
+	res := extractCursor(t, body)
 	if len(res.Diagnostics) != 0 {
 		t.Fatalf("unexpected diagnostics: %+v", res.Diagnostics)
 	}
@@ -268,7 +268,7 @@ func TestExtractCursorSameRecordCommandCorrelation(t *testing.T) {
 func TestExtractCursorJSONPointersAreSourceFaithful(t *testing.T) {
 	t.Run("content_array_blocks", func(t *testing.T) {
 		const body = `{"type":"assistant","id":"a","conversationId":"c","content":[{"type":"text","text":"hi"},{"type":"tool_call","name":"Shell","callId":"s1","input":{"command":"ls"}},{"type":"tool_result","callId":"s1","exitCode":0}]}`
-		acts := activityEvents(extractCursor(t, body, ProfileEvidence).Events)
+		acts := activityEvents(extractCursor(t, body).Events)
 		wantPtr := []string{"/content/0", "/content/1", "/content/2"}
 		if len(acts) != len(wantPtr) {
 			t.Fatalf("got %d events, want %d:\n%s", len(acts), len(wantPtr), dumpEvents(acts))
@@ -282,7 +282,7 @@ func TestExtractCursorJSONPointersAreSourceFaithful(t *testing.T) {
 
 	t.Run("plain_string_content", func(t *testing.T) {
 		const body = `{"type":"user","id":"u","conversationId":"c","content":"hello"}`
-		acts := activityEvents(extractCursor(t, body, ProfileEvidence).Events)
+		acts := activityEvents(extractCursor(t, body).Events)
 		if len(acts) != 1 || acts[0].Evidence.JSONPointer != "/content" {
 			t.Fatalf("plain-string content pointer = %q, want /content:\n%s", ptrOf(acts), dumpEvents(acts))
 		}
@@ -290,7 +290,7 @@ func TestExtractCursorJSONPointersAreSourceFaithful(t *testing.T) {
 
 	t.Run("flat_text_body", func(t *testing.T) {
 		const body = `{"type":"assistant","id":"a","conversationId":"c","text":"just text"}`
-		acts := activityEvents(extractCursor(t, body, ProfileEvidence).Events)
+		acts := activityEvents(extractCursor(t, body).Events)
 		if len(acts) != 1 || acts[0].Evidence.JSONPointer != "/text" {
 			t.Fatalf("flat text pointer = %q, want /text:\n%s", ptrOf(acts), dumpEvents(acts))
 		}
@@ -298,7 +298,7 @@ func TestExtractCursorJSONPointersAreSourceFaithful(t *testing.T) {
 
 	t.Run("top_level_toolCall", func(t *testing.T) {
 		const body = `{"type":"assistant","id":"a","conversationId":"c","toolCall":{"name":"Read","callId":"r1","input":{"file_path":"/x"}}}`
-		acts := activityEvents(extractCursor(t, body, ProfileEvidence).Events)
+		acts := activityEvents(extractCursor(t, body).Events)
 		if len(acts) != 1 || acts[0].Evidence.JSONPointer != "/toolCall" {
 			t.Fatalf("top-level toolCall pointer = %q, want /toolCall:\n%s", ptrOf(acts), dumpEvents(acts))
 		}
@@ -306,7 +306,7 @@ func TestExtractCursorJSONPointersAreSourceFaithful(t *testing.T) {
 
 	t.Run("top_level_toolCalls_list", func(t *testing.T) {
 		const body = `{"type":"assistant","id":"a","conversationId":"c","toolCalls":[{"name":"Read","callId":"r1","input":{"file_path":"/x"}}]}`
-		acts := activityEvents(extractCursor(t, body, ProfileEvidence).Events)
+		acts := activityEvents(extractCursor(t, body).Events)
 		if len(acts) != 1 || acts[0].Evidence.JSONPointer != "/toolCalls/0" {
 			t.Fatalf("top-level toolCalls[0] pointer = %q, want /toolCalls/0:\n%s", ptrOf(acts), dumpEvents(acts))
 		}
@@ -314,7 +314,7 @@ func TestExtractCursorJSONPointersAreSourceFaithful(t *testing.T) {
 
 	t.Run("top_level_toolResult", func(t *testing.T) {
 		const body = `{"type":"tool","id":"t","conversationId":"c","toolResult":{"callId":"r1","isError":true}}`
-		acts := activityEvents(extractCursor(t, body, ProfileEvidence).Events)
+		acts := activityEvents(extractCursor(t, body).Events)
 		if len(acts) != 1 || acts[0].Evidence.JSONPointer != "/toolResult" {
 			t.Fatalf("top-level toolResult pointer = %q, want /toolResult:\n%s", ptrOf(acts), dumpEvents(acts))
 		}
@@ -322,7 +322,7 @@ func TestExtractCursorJSONPointersAreSourceFaithful(t *testing.T) {
 
 	t.Run("top_level_output", func(t *testing.T) {
 		const body = `{"type":"tool","id":"t","conversationId":"c","output":{"callId":"r1","status":"ok"}}`
-		acts := activityEvents(extractCursor(t, body, ProfileEvidence).Events)
+		acts := activityEvents(extractCursor(t, body).Events)
 		if len(acts) != 1 || acts[0].Evidence.JSONPointer != "/output" {
 			t.Fatalf("top-level output pointer = %q, want /output:\n%s", ptrOf(acts), dumpEvents(acts))
 		}

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -98,17 +98,6 @@ func SafeExtract(ex Extractor, r io.Reader, src Source) (res *Result, err error)
 	return res, err
 }
 
-// Profile selects how much an extractor emits. The default (evidence) yields
-// only forensic evidence events; full additionally yields model reasoning
-// (message.reasoning) and session-context fields (model/provider) that are
-// monitoring join keys, not evidence.
-type Profile string
-
-const (
-	ProfileEvidence Profile = "evidence"
-	ProfileFull     Profile = "full"
-)
-
 // Source carries the provenance of one artifact. Keeping it separate from the
 // byte reader lets callers parse embedded fixtures, network sources, or real
 // files through the same Extractor without the parser knowing the difference.
@@ -119,9 +108,9 @@ type Source struct {
 	// CaseID, when set, is stamped on every emitted event so findings from one
 	// investigation share an identifier.
 	CaseID string
-	// Profile selects the capture depth. The zero value ("") is treated as
-	// ProfileEvidence so existing callers keep evidence-only behavior.
-	Profile Profile
+	// IncludeReasoning emits source-recorded reasoning summaries or thinking
+	// blocks. It never infers hidden chain-of-thought.
+	IncludeReasoning bool
 	// CaptureContent retains bounded prompt, assistant, and reasoning bodies for
 	// local rules or indicator extraction. Default output still uses previews.
 	CaptureContent bool
@@ -130,9 +119,6 @@ type Source struct {
 func setMessageContent(ev *model.Event, src Source, raw string) {
 	ev.SetContent(raw, src.CaptureContent)
 }
-
-// fullProfile reports whether the source requests the full capture profile.
-func (s Source) fullProfile() bool { return s.Profile == ProfileFull }
 
 // Result is the output of parsing one artifact.
 type Result struct {

--- a/internal/extract/gemini_session.go
+++ b/internal/extract/gemini_session.go
@@ -265,7 +265,7 @@ func (e GeminiExtractor) emitGeminiSessionMessage(res *Result, src Source, sha, 
 		res.Events = append(res.Events, ev)
 	}
 
-	if src.fullProfile() {
+	if src.IncludeReasoning {
 		for i, thought := range message.Thoughts {
 			content := strings.TrimSpace(strings.TrimSpace(thought.Subject+" ") + thought.Description)
 			if content == "" {
@@ -442,10 +442,8 @@ func (e GeminiExtractor) sessionEvent(src Source, sha, sourceID, kind string, li
 	}
 }
 
-func (GeminiExtractor) stampGeminiSessionModel(ev *model.Event, src Source, name string) {
-	if src.fullProfile() {
-		ev.Model = name
-	}
+func (GeminiExtractor) stampGeminiSessionModel(ev *model.Event, _ Source, name string) {
+	ev.Model = name
 }
 
 func geminiSessionEventID(path, sourceID, kind string) string {

--- a/internal/extract/gemini_test.go
+++ b/internal/extract/gemini_test.go
@@ -115,10 +115,10 @@ func extractGemini(t *testing.T, body string) *Result {
 	return extractGeminiPath(t, "checkpoint-work.json", body)
 }
 
-func extractGeminiSession(t *testing.T, body string, profile Profile) *Result {
+func extractGeminiSession(t *testing.T, body string, includeReasoning bool) *Result {
 	t.Helper()
 	path := filepath.Join("/cases", ".gemini", "tmp", "project", "chats", "session-1.jsonl")
-	res, err := GeminiExtractor{}.Extract(strings.NewReader(body), Source{Path: path, CaseID: "case-g", Profile: profile})
+	res, err := GeminiExtractor{}.Extract(strings.NewReader(body), Source{Path: path, CaseID: "case-g", IncludeReasoning: includeReasoning})
 	if err != nil {
 		t.Fatalf("Extract returned error: %v", err)
 	}
@@ -126,7 +126,7 @@ func extractGeminiSession(t *testing.T, body string, profile Profile) *Result {
 }
 
 func TestExtractGeminiCurrentSessionJournal(t *testing.T) {
-	res := extractGeminiSession(t, geminiSessionFixture, ProfileFull)
+	res := extractGeminiSession(t, geminiSessionFixture, true)
 	if len(res.Diagnostics) != 0 {
 		t.Fatalf("diagnostics = %+v", res.Diagnostics)
 	}
@@ -179,12 +179,19 @@ func TestExtractGeminiCurrentSessionJournal(t *testing.T) {
 	assertUniqueEventIDs(t, res.Events)
 }
 
-func TestExtractGeminiSessionEvidenceProfileDropsModelAndReasoning(t *testing.T) {
-	res := extractGeminiSession(t, geminiSessionFixture, ProfileEvidence)
+func TestExtractGeminiSessionDefaultIncludesModelButDropsReasoning(t *testing.T) {
+	res := extractGeminiSession(t, geminiSessionFixture, false)
+	modelSeen := false
 	for _, ev := range res.Events {
-		if ev.Model != "" || ev.EventType == model.EventMessageReasoning {
-			t.Errorf("evidence profile retained monitoring context: %+v", ev)
+		if ev.EventType == model.EventMessageReasoning {
+			t.Errorf("default extraction surfaced reasoning: %+v", ev)
 		}
+		if ev.Model == "gemini-3-pro" {
+			modelSeen = true
+		}
+	}
+	if !modelSeen {
+		t.Fatal("default extraction omitted source-recorded model identity")
 	}
 }
 
@@ -195,7 +202,7 @@ func TestExtractGeminiLegacySessionObject(t *testing.T) {
   "startTime":"2026-07-14T09:00:00Z",
   "messages":[{"id":"u1","timestamp":"2026-07-14T09:00:01Z","type":"user","content":[{"text":"hello"}]}]
 }`
-	res := extractGeminiSession(t, body, ProfileEvidence)
+	res := extractGeminiSession(t, body, false)
 	acts := activityEvents(res.Events)
 	if len(acts) != 1 || acts[0].EventType != model.EventPromptUser || acts[0].ContentPreview != "hello" {
 		t.Fatalf("legacy session events = %s", dumpEvents(res.Events))
@@ -206,14 +213,14 @@ func TestExtractGeminiLegacySessionObject(t *testing.T) {
 }
 
 func TestExtractGeminiSessionMetadataUpdateDoesNotInventStart(t *testing.T) {
-	res := extractGeminiSession(t, `{"$set":{"lastUpdated":"2026-07-14T09:00:00Z"}}`, ProfileEvidence)
+	res := extractGeminiSession(t, `{"$set":{"lastUpdated":"2026-07-14T09:00:00Z"}}`, false)
 	if len(res.Events) != 0 {
 		t.Fatalf("events = %s, want none", dumpEvents(res.Events))
 	}
 }
 
 func TestExtractGeminiSessionPreservesJournalLineNumbers(t *testing.T) {
-	res := extractGeminiSession(t, "\n"+geminiSessionFixture, ProfileEvidence)
+	res := extractGeminiSession(t, "\n"+geminiSessionFixture, false)
 	if len(res.Events) == 0 || res.Events[0].Evidence.Line != 2 {
 		t.Fatalf("first event evidence = %+v, want line 2", res.Events[0].Evidence)
 	}
@@ -222,7 +229,7 @@ func TestExtractGeminiSessionPreservesJournalLineNumbers(t *testing.T) {
 func TestExtractGeminiSessionSuppressesReadManyResult(t *testing.T) {
 	body := `{"sessionId":"s1","startTime":"2026-07-14T09:00:00Z"}
 {"id":"g1","timestamp":"2026-07-14T09:00:01Z","type":"gemini","content":[],"toolCalls":[{"id":"r1","name":"read_many_files","args":{"include":["**/*.env"]},"result":[{"functionResponse":{"id":"r1","name":"read_many_files","response":{"output":"SECRET=value"}}}],"status":"success","timestamp":"2026-07-14T09:00:02Z"}]}`
-	res := extractGeminiSession(t, body, ProfileEvidence)
+	res := extractGeminiSession(t, body, false)
 	acts := activityEvents(res.Events)
 	if len(acts) != 2 || acts[1].EventType != model.EventToolResult || acts[1].ContentPreview != "" {
 		t.Fatalf("read_many_files events = %s", dumpEvents(acts))

--- a/internal/extract/kimi_code.go
+++ b/internal/extract/kimi_code.go
@@ -229,7 +229,7 @@ func (e KimiCodeExtractor) mapLoopEvent(res *Result, src Source, sha string, st 
 			ev.Evidence.JSONPointer = "/event/part"
 			res.Events = append(res.Events, ev)
 		case "think":
-			if !src.fullProfile() || strings.TrimSpace(event.Part.Think) == "" {
+			if !src.IncludeReasoning || strings.TrimSpace(event.Part.Think) == "" {
 				return
 			}
 			ev := e.base(src, sha, st, line, ts, 0)

--- a/internal/extract/kimi_code_test.go
+++ b/internal/extract/kimi_code_test.go
@@ -100,8 +100,8 @@ func TestKimiCodeExtractMapsCurrentWireRecords(t *testing.T) {
 
 func TestKimiCodeExtractFullProfileIncludesThinking(t *testing.T) {
 	res, err := (KimiCodeExtractor{}).Extract(strings.NewReader(kimiWireFixture), Source{
-		Path:    "/x/.kimi-code/sessions/w/s/agents/main/wire.jsonl",
-		Profile: ProfileFull,
+		Path:             "/x/.kimi-code/sessions/w/s/agents/main/wire.jsonl",
+		IncludeReasoning: true,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/extract/opencode.go
+++ b/internal/extract/opencode.go
@@ -99,9 +99,7 @@ func (e OpenCodeExtractor) extractMessage(res *Result, src Source, sha string, m
 	ev.Confidence = model.ConfidenceHigh
 	ev.Evidence.JSONPointer = "/role"
 	ev.ProjectPath = message.Path.CWD
-	if src.fullProfile() {
-		ev.Model, ev.ModelProvider = message.modelIdentity()
-	}
+	ev.Model, ev.ModelProvider = message.modelIdentity()
 	switch message.Role {
 	case openCodeRoleUser:
 		ev.EventType = model.EventPromptUser

--- a/internal/extract/opencode_test.go
+++ b/internal/extract/opencode_test.go
@@ -15,12 +15,12 @@ import (
 // is exercised the same way on every OS, and the helper stays macOS-symlink safe
 // by never comparing a full path.
 func extractOpenCodePath(t *testing.T, path, body string) *Result {
-	return extractOpenCodePathProfile(t, path, body, ProfileEvidence)
+	return extractOpenCodePathWithReasoning(t, path, body, false)
 }
 
-func extractOpenCodePathProfile(t *testing.T, path, body string, profile Profile) *Result {
+func extractOpenCodePathWithReasoning(t *testing.T, path, body string, includeReasoning bool) *Result {
 	t.Helper()
-	res, err := OpenCodeExtractor{}.Extract(strings.NewReader(body), Source{Path: path, CaseID: "case-oc", Profile: profile})
+	res, err := OpenCodeExtractor{}.Extract(strings.NewReader(body), Source{Path: path, CaseID: "case-oc", IncludeReasoning: includeReasoning})
 	if err != nil {
 		t.Fatalf("Extract returned error: %v", err)
 	}
@@ -34,11 +34,11 @@ func extractOpenCode(t *testing.T, body string) *Result {
 	return extractOpenCodePath(t, path, body)
 }
 
-// extractOpenCodeProfile parses body with an explicit capture profile.
-func extractOpenCodeProfile(t *testing.T, body string, profile Profile) *Result {
+// extractOpenCodeWithReasoning parses body with an explicit reasoning setting.
+func extractOpenCodeWithReasoning(t *testing.T, body string, includeReasoning bool) *Result {
 	t.Helper()
 	path := filepath.Join("/cases", "opencode", "storage", "part", "msg1", "prt1.json")
-	res, err := OpenCodeExtractor{}.Extract(strings.NewReader(body), Source{Path: path, CaseID: "case-oc", Profile: profile})
+	res, err := OpenCodeExtractor{}.Extract(strings.NewReader(body), Source{Path: path, CaseID: "case-oc", IncludeReasoning: includeReasoning})
 	if err != nil {
 		t.Fatalf("Extract returned error: %v", err)
 	}
@@ -427,19 +427,18 @@ func TestOpenCodePatchInvalidHash(t *testing.T) {
 
 // TestOpenCodeTextAndReasoningAreNoOps proves text and reasoning parts are
 // prose-only and OUT of scope for this forensic parser: they emit NO event and
-// store NO preview, in either profile, so numbat never retains assistant prose
-// or model reasoning. Their absence is by design, so it is not a diagnostic gap
-// either.
+// store NO preview, so numbat never retains assistant prose or model reasoning.
+// Their absence is by design, so it is not a diagnostic gap either.
 func TestOpenCodeTextAndReasoningAreNoOps(t *testing.T) {
 	for _, body := range []string{
 		`{"type":"text","text":"here is the plan"}`,
 		`{"type":"reasoning","text":"let me think"}`,
 	} {
 		if r := extractOpenCode(t, body); len(r.Events) != 0 || len(r.Diagnostics) != 0 {
-			t.Errorf("evidence profile %s: want no events and no diagnostics, got events=%+v diags=%+v", body, r.Events, r.Diagnostics)
+			t.Errorf("default %s: want no events and no diagnostics, got events=%+v diags=%+v", body, r.Events, r.Diagnostics)
 		}
-		if r := extractOpenCodeProfile(t, body, ProfileFull); len(r.Events) != 0 || len(r.Diagnostics) != 0 {
-			t.Errorf("full profile %s: want no events and no diagnostics, got events=%+v diags=%+v", body, r.Events, r.Diagnostics)
+		if r := extractOpenCodeWithReasoning(t, body, true); len(r.Events) != 0 || len(r.Diagnostics) != 0 {
+			t.Errorf("with reasoning %s: want no events and no diagnostics, got events=%+v diags=%+v", body, r.Events, r.Diagnostics)
 		}
 	}
 }
@@ -458,11 +457,11 @@ func TestOpenCodeMessageRole(t *testing.T) {
 	if res.Events[0].SessionID != "s1" || res.Events[0].Timestamp != "2023-11-14T22:13:20Z" {
 		t.Errorf("user message context = session %q at %q", res.Events[0].SessionID, res.Events[0].Timestamp)
 	}
-	if res.Events[0].Model != "" || res.Events[0].ModelProvider != "" {
-		t.Errorf("evidence profile retained model identity: %+v", res.Events[0])
+	if res.Events[0].Model != "gpt-5" || res.Events[0].ModelProvider != "openai" {
+		t.Errorf("default extraction omitted model identity: %+v", res.Events[0])
 	}
 
-	asst := extractOpenCodePathProfile(t, userPath, `{"id":"m1","sessionID":"s1","role":"assistant","time":{"created":1700000000123},"modelID":"gpt-5","providerID":"openai","path":{"cwd":"/repo"}}`, ProfileFull)
+	asst := extractOpenCodePathWithReasoning(t, userPath, `{"id":"m1","sessionID":"s1","role":"assistant","time":{"created":1700000000123},"modelID":"gpt-5","providerID":"openai","path":{"cwd":"/repo"}}`, true)
 	if len(asst.Events) != 1 || asst.Events[0].EventType != model.EventMessageAssistant {
 		t.Fatalf("assistant message: got %+v, want message.assistant", asst.Events)
 	}
@@ -562,7 +561,7 @@ func TestOpenCodeEventsSatisfyContract(t *testing.T) {
 		`{"id":"m2","role":"assistant","time":{"created":1}}`,
 	}
 	for _, body := range bodies {
-		res := extractOpenCodeProfile(t, body, ProfileFull)
+		res := extractOpenCodeWithReasoning(t, body, true)
 		if len(res.Events) == 0 {
 			t.Fatalf("body produced no events: %s", body)
 		}

--- a/internal/extract/pi.go
+++ b/internal/extract/pi.go
@@ -231,7 +231,7 @@ func (e PiExtractor) mapAssistantBlock(res *Result, src Source, sha string, st *
 		ev.Evidence.JSONPointer = pointer
 		res.Events = append(res.Events, ev)
 	case piBlockThinking:
-		if !src.fullProfile() || strings.TrimSpace(block.Thinking) == "" {
+		if !src.IncludeReasoning || strings.TrimSpace(block.Thinking) == "" {
 			return
 		}
 		ev := e.base(src, sha, st, line, ts, idx)

--- a/internal/extract/pi_test.go
+++ b/internal/extract/pi_test.go
@@ -86,8 +86,8 @@ func TestPiExtractMapsDocumentedSessionRecords(t *testing.T) {
 
 func TestPiExtractFullProfileIncludesReasoning(t *testing.T) {
 	res, err := (PiExtractor{}).Extract(strings.NewReader(piSessionFixture), Source{
-		Path:    "/home/u/.pi/agent/sessions/s.jsonl",
-		Profile: ProfileFull,
+		Path:             "/home/u/.pi/agent/sessions/s.jsonl",
+		IncludeReasoning: true,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/extract/windsurf_test.go
+++ b/internal/extract/windsurf_test.go
@@ -16,9 +16,9 @@ import (
 const windsurfFixture = `{"type":"user","id":"wu1","trajectoryId":"traj-1","timestamp":"2026-06-03T10:00:00Z","cwd":"/home/dev/proj","content":"why is the auth middleware failing?"}
 {"type":"assistant","id":"wa1","trajectoryId":"traj-1","timestamp":"2026-06-03T10:00:01Z","cwd":"/home/dev/proj","content":[{"type":"text","text":"Let me run the tests."},{"type":"tool_call","name":"run_command","callId":"t1","input":{"command":"go test ./..."}},{"type":"tool_result","callId":"t1","exitCode":1,"isError":true}]}`
 
-func extractWindsurf(t *testing.T, body string, profile Profile) *Result {
+func extractWindsurf(t *testing.T, body string) *Result {
 	t.Helper()
-	res, err := WindsurfExtractor{}.Extract(strings.NewReader(body), Source{Path: "/cases/windsurf.jsonl", CaseID: "case-ws", Profile: profile})
+	res, err := WindsurfExtractor{}.Extract(strings.NewReader(body), Source{Path: "/cases/windsurf.jsonl", CaseID: "case-ws"})
 	if err != nil {
 		t.Fatalf("Extract returned error: %v", err)
 	}
@@ -30,7 +30,7 @@ func extractWindsurf(t *testing.T, body string, profile Profile) *Result {
 // code — every event stamped with the windsurf source identity and the windsurf
 // artifact type. This is the headline correlation+exit-code proof.
 func TestExtractWindsurfMapsShapesWithWindsurfIdentity(t *testing.T) {
-	res := extractWindsurf(t, windsurfFixture, ProfileEvidence)
+	res := extractWindsurf(t, windsurfFixture)
 	if len(res.Diagnostics) != 0 {
 		t.Fatalf("unexpected diagnostics: %+v", res.Diagnostics)
 	}
@@ -107,7 +107,7 @@ func TestExtractWindsurfMapsShapesWithWindsurfIdentity(t *testing.T) {
 func TestExtractWindsurfNonCommandResultAndError(t *testing.T) {
 	const body = `{"type":"assistant","id":"a","trajectoryId":"c","content":[{"type":"tool_call","name":"read_code","callId":"r1","input":{"file_path":"/etc/hosts"}}]}
 {"type":"tool","id":"b","trajectoryId":"c","toolResult":{"callId":"r1","isError":true}}`
-	res := extractWindsurf(t, body, ProfileEvidence)
+	res := extractWindsurf(t, body)
 	acts := activityEvents(res.Events)
 	if len(acts) != 2 {
 		t.Fatalf("got %d activity events, want 2:\n%s", len(acts), dumpEvents(res.Events))
@@ -127,7 +127,7 @@ func TestExtractWindsurfNonCommandResultAndError(t *testing.T) {
 // and the network tag, mirroring the Cursor/Claude classifiers.
 func TestExtractWindsurfReadURLNetworkIndicator(t *testing.T) {
 	const body = `{"type":"assistant","id":"a","trajectoryId":"c","content":[{"type":"tool_call","name":"read_url_content","callId":"w1","input":{"url":"https://example.com/x"}}]}`
-	res := extractWindsurf(t, body, ProfileEvidence)
+	res := extractWindsurf(t, body)
 	acts := activityEvents(res.Events)
 	if len(acts) != 1 {
 		t.Fatalf("got %d activity events, want 1:\n%s", len(acts), dumpEvents(res.Events))
@@ -147,7 +147,7 @@ func TestExtractWindsurfReadURLNetworkIndicator(t *testing.T) {
 func TestExtractWindsurfReadURLRejectsNonHTTPScheme(t *testing.T) {
 	const bad = "file:///etc/passwd"
 	const body = `{"type":"assistant","id":"a","trajectoryId":"c","content":[{"type":"tool_call","name":"read_url_content","callId":"w1","input":{"url":"file:///etc/passwd"}}]}`
-	acts := activityEvents(extractWindsurf(t, body, ProfileEvidence).Events)
+	acts := activityEvents(extractWindsurf(t, body).Events)
 	if len(acts) != 1 {
 		t.Fatalf("got %d activity events, want 1", len(acts))
 	}
@@ -172,7 +172,7 @@ func TestExtractWindsurfToleratesMalformedLine(t *testing.T) {
 	const body = `{"type":"user","id":"u","trajectoryId":"c","content":"hello"}
 {not json}
 {"type":"assistant","id":"a","trajectoryId":"c","content":"hi"}`
-	res := extractWindsurf(t, body, ProfileEvidence)
+	res := extractWindsurf(t, body)
 	if len(res.Diagnostics) != 1 {
 		t.Fatalf("got %d diagnostics, want 1: %+v", len(res.Diagnostics), res.Diagnostics)
 	}
@@ -190,7 +190,7 @@ func TestExtractWindsurfToleratesMalformedLine(t *testing.T) {
 func TestExtractWindsurfCrossRecordCommandCorrelation(t *testing.T) {
 	const body = `{"type":"assistant","id":"a","trajectoryId":"c","content":[{"type":"tool_call","name":"run_command","callId":"s1","input":{"command":"ls -la"}}]}
 {"type":"tool","id":"t","trajectoryId":"c","toolResult":{"callId":"s1","exitCode":0}}`
-	res := extractWindsurf(t, body, ProfileEvidence)
+	res := extractWindsurf(t, body)
 	acts := activityEvents(res.Events)
 	if len(acts) != 2 {
 		t.Fatalf("got %d activity events, want 2:\n%s", len(acts), dumpEvents(res.Events))
@@ -229,7 +229,7 @@ func TestExtractWindsurfSameRecordTopLevelCorrelationOrdering(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			res := extractWindsurf(t, tc.body, ProfileEvidence)
+			res := extractWindsurf(t, tc.body)
 			acts := activityEvents(res.Events)
 			if len(acts) != 2 {
 				t.Fatalf("got %d activity events, want 2:\n%s", len(acts), dumpEvents(res.Events))
@@ -263,7 +263,7 @@ func TestExtractWindsurfSameRecordTopLevelCorrelationOrdering(t *testing.T) {
 func TestExtractWindsurfJSONPointersAreSourceFaithful(t *testing.T) {
 	t.Run("plain_string_content", func(t *testing.T) {
 		const body = `{"type":"user","id":"u","trajectoryId":"c","content":"hello"}`
-		acts := activityEvents(extractWindsurf(t, body, ProfileEvidence).Events)
+		acts := activityEvents(extractWindsurf(t, body).Events)
 		if len(acts) != 1 || acts[0].Evidence.JSONPointer != "/content" {
 			t.Fatalf("plain-string content pointer = %q, want /content:\n%s", ptrOf(acts), dumpEvents(acts))
 		}
@@ -271,7 +271,7 @@ func TestExtractWindsurfJSONPointersAreSourceFaithful(t *testing.T) {
 
 	t.Run("flat_text_body", func(t *testing.T) {
 		const body = `{"type":"assistant","id":"a","trajectoryId":"c","text":"just text"}`
-		acts := activityEvents(extractWindsurf(t, body, ProfileEvidence).Events)
+		acts := activityEvents(extractWindsurf(t, body).Events)
 		if len(acts) != 1 || acts[0].Evidence.JSONPointer != "/text" {
 			t.Fatalf("flat text pointer = %q, want /text:\n%s", ptrOf(acts), dumpEvents(acts))
 		}
@@ -279,7 +279,7 @@ func TestExtractWindsurfJSONPointersAreSourceFaithful(t *testing.T) {
 
 	t.Run("top_level_toolCall", func(t *testing.T) {
 		const body = `{"type":"assistant","id":"a","trajectoryId":"c","toolCall":{"name":"read_code","callId":"r1","input":{"file_path":"/x"}}}`
-		acts := activityEvents(extractWindsurf(t, body, ProfileEvidence).Events)
+		acts := activityEvents(extractWindsurf(t, body).Events)
 		if len(acts) != 1 || acts[0].Evidence.JSONPointer != "/toolCall" {
 			t.Fatalf("top-level toolCall pointer = %q, want /toolCall:\n%s", ptrOf(acts), dumpEvents(acts))
 		}
@@ -287,7 +287,7 @@ func TestExtractWindsurfJSONPointersAreSourceFaithful(t *testing.T) {
 
 	t.Run("top_level_toolCalls_list", func(t *testing.T) {
 		const body = `{"type":"assistant","id":"a","trajectoryId":"c","toolCalls":[{"name":"read_code","callId":"r1","input":{"file_path":"/x"}}]}`
-		acts := activityEvents(extractWindsurf(t, body, ProfileEvidence).Events)
+		acts := activityEvents(extractWindsurf(t, body).Events)
 		if len(acts) != 1 || acts[0].Evidence.JSONPointer != "/toolCalls/0" {
 			t.Fatalf("top-level toolCalls[0] pointer = %q, want /toolCalls/0:\n%s", ptrOf(acts), dumpEvents(acts))
 		}
@@ -295,7 +295,7 @@ func TestExtractWindsurfJSONPointersAreSourceFaithful(t *testing.T) {
 
 	t.Run("top_level_toolResult", func(t *testing.T) {
 		const body = `{"type":"tool","id":"t","trajectoryId":"c","toolResult":{"callId":"r1","isError":true}}`
-		acts := activityEvents(extractWindsurf(t, body, ProfileEvidence).Events)
+		acts := activityEvents(extractWindsurf(t, body).Events)
 		if len(acts) != 1 || acts[0].Evidence.JSONPointer != "/toolResult" {
 			t.Fatalf("top-level toolResult pointer = %q, want /toolResult:\n%s", ptrOf(acts), dumpEvents(acts))
 		}
@@ -303,7 +303,7 @@ func TestExtractWindsurfJSONPointersAreSourceFaithful(t *testing.T) {
 
 	t.Run("top_level_output", func(t *testing.T) {
 		const body = `{"type":"tool","id":"t","trajectoryId":"c","output":{"callId":"r1","status":"ok"}}`
-		acts := activityEvents(extractWindsurf(t, body, ProfileEvidence).Events)
+		acts := activityEvents(extractWindsurf(t, body).Events)
 		if len(acts) != 1 || acts[0].Evidence.JSONPointer != "/output" {
 			t.Fatalf("top-level output pointer = %q, want /output:\n%s", ptrOf(acts), dumpEvents(acts))
 		}

--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -394,6 +394,10 @@ func (e *Event) SetContent(raw string, retain bool) {
 // when evaluating a caller-supplied event record.
 func (e Event) ContentForAnalysis() string { return e.contentForAnalysis() }
 
+// ContentBytesForAnalysis returns the mapped message-body byte count recorded
+// before Numbat's content bound was applied.
+func (e Event) ContentBytesForAnalysis() int { return e.contentBytesForAnalysis() }
+
 // ContentTruncatedForAnalysis reports whether ContentForAnalysis omits bytes.
 func (e Event) ContentTruncatedForAnalysis() bool { return e.contentTruncatedForAnalysis() }
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -161,6 +161,8 @@ type StatsReporter interface {
 type Emitter struct {
 	runID    string
 	endpoint Endpoint
+	// fullContent is fixed by a constructor option before concurrent use.
+	fullContent bool
 
 	mu                sync.Mutex
 	sink              Sink
@@ -171,6 +173,15 @@ type Emitter struct {
 	indicatorsEmitted int
 	diagnostics       int
 	recordErrors      int
+}
+
+// EmitterOption configures an Emitter before it is used.
+type EmitterOption func(*Emitter)
+
+// WithFullContent includes redacted, bounded conversation content in event
+// records. The default projection emits only content_preview.
+func WithFullContent() EmitterOption {
+	return func(e *Emitter) { e.fullContent = true }
 }
 
 // Stats is a point-in-time snapshot of emitter counters.
@@ -186,36 +197,44 @@ type Stats struct {
 // diags. runID is stamped on every emitted line for correlation. If records is
 // already a Sink it is used directly; otherwise it is wrapped in a no-op-close
 // adapter so a bare io.Writer (stdout, a test buffer) keeps working unchanged.
-func New(records, diags io.Writer, runID string) *Emitter {
+func New(records, diags io.Writer, runID string, opts ...EmitterOption) *Emitter {
 	sink, ok := records.(Sink)
 	if !ok {
 		sink = nopCloseSink{records}
 	}
-	return NewWithSink(sink, diags, runID)
+	return NewWithSink(sink, diags, runID, opts...)
 }
 
 // NewWithSink constructs an Emitter writing records to an explicit Sink. The
 // sink is closed by Emitter.Close (which must be called last, after the
 // terminal scan_summary, so a batching sink flushes its final batch).
-func NewWithSink(sink Sink, diags io.Writer, runID string) *Emitter {
-	return &Emitter{
+func NewWithSink(sink Sink, diags io.Writer, runID string, opts ...EmitterOption) *Emitter {
+	e := &Emitter{
 		runID:    runID,
 		endpoint: defaultEndpoint(),
 		sink:     sink,
 		diags:    json.NewEncoder(diags),
 	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
 }
 
 // NewWithSinkAndDiagnostics constructs an Emitter that writes diagnostics as
 // records on sink. It is for runtimes where stderr belongs to the invoking host
 // rather than the operator.
-func NewWithSinkAndDiagnostics(sink Sink, runID string) *Emitter {
-	return &Emitter{
+func NewWithSinkAndDiagnostics(sink Sink, runID string, opts ...EmitterOption) *Emitter {
+	e := &Emitter{
 		runID:             runID,
 		endpoint:          defaultEndpoint(),
 		sink:              sink,
 		diagnosticsInSink: true,
 	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
 }
 
 // nopCloseSink adapts a bare io.Writer to a Sink whose Close is a no-op, so the
@@ -276,7 +295,13 @@ func (e *Emitter) EmitFinding(f model.Finding) error {
 func (e *Emitter) EmitEvent(ev model.Event) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	if err := e.emitLocked(RecordEvent, redact.Event(ev)); err != nil {
+	var projected model.Event
+	if e.fullContent {
+		projected = redact.EventWithContent(ev)
+	} else {
+		projected = redact.Event(ev)
+	}
+	if err := e.emitLocked(RecordEvent, projected); err != nil {
 		e.recordErrors++
 		return err
 	}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -78,6 +78,37 @@ func TestEmitFindingNDJSON(t *testing.T) {
 	}
 }
 
+func TestEmitEventContentProjection(t *testing.T) {
+	raw := strings.Repeat("prefix ", 35) + "sk-abcdefghijklmnopqrstuvwxyz0123456789"
+	ev := model.Event{SchemaVersion: model.SchemaVersion, EventID: "ev-content", EventType: model.EventPromptUser}
+	ev.SetContent(raw, true)
+
+	var preview, full bytes.Buffer
+	if err := New(&preview, io.Discard, "run-preview").EmitEvent(ev); err != nil {
+		t.Fatal(err)
+	}
+	if err := New(&full, io.Discard, "run-full", WithFullContent()).EmitEvent(ev); err != nil {
+		t.Fatal(err)
+	}
+
+	var previewRecord, fullRecord model.Event
+	if err := json.Unmarshal(preview.Bytes(), &previewRecord); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(full.Bytes(), &fullRecord); err != nil {
+		t.Fatal(err)
+	}
+	if previewRecord.Content != "" || previewRecord.ContentBytes != 0 {
+		t.Fatalf("default emitter retained content: %+v", previewRecord)
+	}
+	if fullRecord.Content == "" || strings.Contains(fullRecord.Content, "sk-abcdefghijklmnopqrstuvwxyz0123456789") {
+		t.Fatalf("full emitter omitted or leaked content: %+v", fullRecord)
+	}
+	if fullRecord.ContentBytes != len(raw) {
+		t.Fatalf("content_bytes = %d, want %d", fullRecord.ContentBytes, len(raw))
+	}
+}
+
 func TestDiagnosticsCanShareRecordSink(t *testing.T) {
 	var records bytes.Buffer
 	e := NewWithSinkAndDiagnostics(nopCloseSink{&records}, "run1")

--- a/internal/redact/redact_event.go
+++ b/internal/redact/redact_event.go
@@ -16,10 +16,13 @@ import "github.com/perplexityai/numbat/internal/model"
 // event sink and the timeline renderer instead of duplicating the field list at
 // each call site.
 func Event(ev model.Event) model.Event {
+	ev = ev.WithoutAnalysisContent()
 	ev.Command = String(ev.Command)
 	ev.FilePath = String(ev.FilePath)
 	ev.URL = String(ev.URL)
-	ev.ContentPreview = String(ev.ContentPreview)
+	var previewTruncated bool
+	ev.ContentPreview, previewTruncated = model.NormalizeContentPreviewWithTruncation(String(ev.ContentPreview))
+	ev.ContentPreviewTruncated = ev.ContentPreviewTruncated || previewTruncated
 	ev.Content = ""
 	ev.ContentBytes = 0
 	ev.ContentTruncated = false
@@ -27,6 +30,24 @@ func Event(ev model.Event) model.Event {
 	ev.MCPTool = String(ev.MCPTool)
 	ev.ProjectPath = String(ev.ProjectPath)
 	ev.ApprovalReason = String(ev.ApprovalReason)
+	return ev
+}
+
+// EventWithContent returns the explicit full-content projection. The retained
+// body is still redacted, while its byte count describes the mapped text before
+// Numbat's content bound and output redaction were applied.
+func EventWithContent(ev model.Event) model.Event {
+	content := ev.ContentForAnalysis()
+	contentBytes := ev.ContentBytesForAnalysis()
+	contentTruncated := ev.ContentTruncatedForAnalysis()
+	ev = Event(ev)
+	if content == "" {
+		return ev
+	}
+	var outputTruncated bool
+	ev.Content, outputTruncated = model.LimitContent(String(content))
+	ev.ContentBytes = contentBytes
+	ev.ContentTruncated = contentTruncated || outputTruncated
 	return ev
 }
 
@@ -40,6 +61,18 @@ func Events(evs []model.Event) []model.Event {
 	out := make([]model.Event, len(evs))
 	for i, ev := range evs {
 		out[i] = Event(ev)
+	}
+	return out
+}
+
+// EventsWithContent is the slice form of EventWithContent.
+func EventsWithContent(evs []model.Event) []model.Event {
+	if evs == nil {
+		return nil
+	}
+	out := make([]model.Event, len(evs))
+	for i, ev := range evs {
+		out[i] = EventWithContent(ev)
 	}
 	return out
 }

--- a/internal/redact/redact_event_test.go
+++ b/internal/redact/redact_event_test.go
@@ -3,6 +3,7 @@ package redact
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/perplexityai/numbat/internal/model"
 )
@@ -56,6 +57,9 @@ func TestEventRedactsObservedFields(t *testing.T) {
 	if got.Content != "" || got.ContentBytes != 0 || got.ContentTruncated {
 		t.Errorf("default projection retained full content: %+v", got)
 	}
+	if got.ContentForAnalysis() != "" {
+		t.Error("default projection retained hidden analysis content")
+	}
 	// Closed-vocabulary / non-secret fields are copied verbatim.
 	if got.ToolName != "Bash" || got.EventType != model.EventCommandExec || got.EventID != "e1" {
 		t.Errorf("non-observed fields altered: %+v", got)
@@ -66,10 +70,52 @@ func TestEventRedactsObservedFields(t *testing.T) {
 	}
 }
 
+func TestEventBoundsPreviewAfterRedactionExpansion(t *testing.T) {
+	in := model.Event{ContentPreview: strings.Repeat("Authorization: Bearer x ", 8)}
+	got := Event(in)
+	if utf8.RuneCountInString(got.ContentPreview) > model.ContentPreviewMaxRunes || !got.ContentPreviewTruncated {
+		t.Fatalf("preview = %d runes, truncated=%t", utf8.RuneCountInString(got.ContentPreview), got.ContentPreviewTruncated)
+	}
+}
+
 func TestEventRedactsSecretInProjectPath(t *testing.T) {
 	got := Event(model.Event{ProjectPath: "/repo/" + canaryOpen})
 	if strings.Contains(got.ProjectPath, canaryOpen) || !strings.Contains(got.ProjectPath, Mask) {
 		t.Errorf("project path was not redacted: %q", got.ProjectPath)
+	}
+}
+
+func TestEventWithContentRedactsRetainedBody(t *testing.T) {
+	raw := strings.Repeat("context ", 30) + canaryOpen + "\nsecond line"
+	in := model.Event{EventID: "e-content", EventType: model.EventPromptUser}
+	in.SetContent(raw, true)
+
+	got := EventWithContent(in)
+	if got.Content == "" || strings.Contains(got.Content, canaryOpen) || !strings.Contains(got.Content, Mask) {
+		t.Fatalf("full content was not redacted: %q", got.Content)
+	}
+	if got.ContentBytes != len(raw) || got.ContentTruncated {
+		t.Fatalf("content metadata = %d/%v, want %d/false", got.ContentBytes, got.ContentTruncated, len(raw))
+	}
+	if !strings.Contains(got.Content, "\nsecond line") {
+		t.Errorf("full content lost message formatting: %q", got.Content)
+	}
+	if got.ContentForAnalysis() != got.Content {
+		t.Error("full projection retained an unredacted analysis copy")
+	}
+	if in.Content != "" || !strings.Contains(in.ContentForAnalysis(), canaryOpen) {
+		t.Fatal("full-content projection mutated its input")
+	}
+}
+
+func TestEventWithContentBoundsRedactionExpansion(t *testing.T) {
+	raw := strings.Repeat("Authorization: Bearer x\n", model.ContentMaxBytes/24)
+	in := model.Event{EventID: "e-expanded", EventType: model.EventPromptUser}
+	in.SetContent(raw, true)
+
+	got := EventWithContent(in)
+	if len(got.Content) > model.ContentMaxBytes || !got.ContentTruncated {
+		t.Fatalf("expanded content = %d bytes, truncated=%t", len(got.Content), got.ContentTruncated)
 	}
 }
 
@@ -101,5 +147,11 @@ func TestEventsSliceRedactsEachAndPreservesNil(t *testing.T) {
 	}
 	if strings.Contains(out[1].URL, canarySig) {
 		t.Errorf("element 1 not redacted: %q", out[1].URL)
+	}
+}
+
+func TestEventsWithContentPreservesNil(t *testing.T) {
+	if EventsWithContent(nil) != nil {
+		t.Error("EventsWithContent(nil) should be nil")
 	}
 }

--- a/internal/redact/redact_event_test.go
+++ b/internal/redact/redact_event_test.go
@@ -119,6 +119,17 @@ func TestEventWithContentBoundsRedactionExpansion(t *testing.T) {
 	}
 }
 
+func TestEventWithContentPreservesSourceSizeWhenBounded(t *testing.T) {
+	raw := strings.Repeat("x", model.ContentMaxBytes+1)
+	in := model.Event{EventID: "e-bounded", EventType: model.EventPromptUser}
+	in.SetContent(raw, true)
+
+	got := EventWithContent(in)
+	if len(got.Content) != model.ContentMaxBytes || got.ContentBytes != len(raw) || !got.ContentTruncated {
+		t.Fatalf("content metadata = %d/%d/%t", len(got.Content), got.ContentBytes, got.ContentTruncated)
+	}
+}
+
 // TestEventEmptyFieldsStayEmpty confirms Event is nil/empty-safe: an empty field
 // in yields an empty field out, so omitempty still drops it on emission.
 func TestEventEmptyFieldsStayEmpty(t *testing.T) {


### PR DESCRIPTION
## Summary
- separate content retention (`--content preview|full`) from reasoning selection (`--include-reasoning`)
- apply bounded full-content output consistently to scan, timeline JSON, collect, and hooks
- emit source-provided model and provider context without coupling it to content depth
- retain deprecated `--profile evidence|full` compatibility for scan and timeline; `full` enables reasoning only

`--content full` remains redacted and capped at 1 MiB per event. `--include-reasoning` includes only reasoning persisted or exposed by the source.

## Verification
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- golangci-lint v2.12.2

Stack: 2 of 3. Depends on #31.