### PR TITLE
build: update Go to 1.26.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           check-latest: true
 
       - name: go mod tidy
@@ -74,7 +74,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           check-latest: true
 
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
@@ -98,7 +98,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           check-latest: true
 
       # Bounded fuzzing: each target runs briefly to surface crashers without
@@ -127,7 +127,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           check-latest: true
 
       # Non-gating: report total coverage for visibility, never fail the build
@@ -162,7 +162,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           check-latest: true
 
       - name: install govulncheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           check-latest: true
 
       - name: verify tag is reachable from main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ deterministic, endpoint-local design and the architecture boundaries below.
 
 ## Development setup
 
-Use Go 1.26.5 or newer; CI pins 1.26.5.
+Use Go 1.26.6 or newer; CI pins 1.26.6.
 
 ```sh
 go build ./cmd/numbat

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ synchronous pre-action hooks; see the [enforcement guide](docs/enforcement.md).
 
 [Download a release](https://github.com/perplexityai/numbat/releases) for macOS, Linux,
 or Windows on amd64 or arm64. Each release includes SHA-256 checksums. You can
-also install with Go 1.26.5 or newer:
+also install with Go 1.26.6 or newer:
 
 ```
 go install github.com/perplexityai/numbat/cmd/numbat@latest

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -883,7 +883,7 @@ shall terminate as of the date such litigation is filed.
 ==============================================================================
 golang.org/x/sys v0.47.0 (LICENSE)
 golang.org/x/text v0.39.0 (LICENSE)
-Go standard library release toolchain: Go 1.26.5 (LICENSE)
+Go standard library release toolchain: Go 1.26.6 (LICENSE)
 ==============================================================================
 
 Copyright 2009 The Go Authors.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/perplexityai/numbat
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/google/cel-go v0.30.0


### PR DESCRIPTION
## Summary
- update the required and CI/release Go toolchain from 1.26.5 to 1.26.6
- clear newly published standard-library vulnerabilities reported by govulncheck

## Verification
- `go mod tidy`
- `go test ./...`
- `govulncheck ./...` (`No vulnerabilities found`)
