### PR TITLE
fix(rule): harden PowerShell projection and fuzz coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,17 +101,25 @@ jobs:
           go-version: "1.26.6"
           check-latest: true
 
-      # Bounded fuzzing: each target runs briefly to surface crashers without
-      # turning into an open-ended job. The parsers and the redaction decoder
-      # must survive arbitrary and malformed input without panicking.
+      # Each invocation selects one target, so keep every FuzzXxx function in
+      # the tree listed here. Runs are bounded to keep the job predictable.
       - name: fuzz extract parsers
         run: |
-          for t in FuzzClaudeExtract FuzzCodexExtract FuzzGeminiExtract FuzzPiExtract FuzzKimiCodeExtract; do
+          for t in FuzzClaudeExtract FuzzCodexExtract FuzzGeminiExtract FuzzPiExtract \
+                   FuzzKimiCodeExtract FuzzGeminiSessionExtract FuzzCursorExtract \
+                   FuzzWindsurfExtract FuzzOpenCodeExtract FuzzOpenClawExtract \
+                   FuzzCodexCodeModeExecCommand; do
             go test -run='^$' -fuzz="^${t}$" -fuzztime=30s ./internal/extract/
           done
 
       - name: fuzz redaction decoder
-        run: go test -run='^$' -fuzz='^FuzzString$' -fuzztime=30s ./internal/redact/
+        run: |
+          for t in FuzzString FuzzJSONProducesValidJSON; do
+            go test -run='^$' -fuzz="^${t}$" -fuzztime=30s ./internal/redact/
+          done
+
+      - name: fuzz shell command analysis
+        run: go test -run='^$' -fuzz='^FuzzAnalyzeShellCommands$' -fuzztime=30s ./internal/rule/
 
       - name: fuzz OTLP decoder
         run: go test -run='^$' -fuzz='^FuzzOTLPLogs$' -fuzztime=30s ./internal/otel/

--- a/internal/rule/powershell.go
+++ b/internal/rule/powershell.go
@@ -476,6 +476,11 @@ func (a *shellAnalyzer) addPowerShellSegment(segment string, depth int, wrappers
 		a.report(errors.New("shell command analysis: unsupported or malformed PowerShell command"))
 		return
 	}
+	// An empty quoted call target is static text, but it is not executable.
+	if callOperator && command.Executable == "" {
+		a.report(errors.New("shell command analysis: PowerShell call operator without executable"))
+		return
+	}
 	if recognizedPowerShellAlias(command.Executable) {
 		command.enforcementUnsafe = true
 	}

--- a/internal/rule/shell_test.go
+++ b/internal/rule/shell_test.go
@@ -1497,6 +1497,23 @@ func FuzzAnalyzeShellCommands(f *testing.F) {
 	})
 }
 
+func TestPowerShellEmptyCallTargetIsNotProjected(t *testing.T) {
+	t.Parallel()
+	for _, source := range []string{`& ''`, `& ""`, `& '' > C:\out`} {
+		source := source
+		t.Run(source, func(t *testing.T) {
+			t.Parallel()
+			analysis := analyzeShellCommandsDetailed(source, dialectPowerShell)
+			if len(analysis.commands) != 0 {
+				t.Fatalf("commands = %#v, want none", analysis.commands)
+			}
+			if analysis.usable || analysis.enforcementSafe || analysis.err == nil {
+				t.Fatalf("analysis = usable:%v enforcementSafe:%v err:%v", analysis.usable, analysis.enforcementSafe, analysis.err)
+			}
+		})
+	}
+}
+
 func BenchmarkAnalyzeShellCommands(b *testing.B) {
 	for _, size := range []int{64, 12 << 10, maxShellCommandBytes} {
 		source := "echo " + strings.Repeat("x", size-len("echo "))

--- a/internal/rule/testdata/fuzz/FuzzAnalyzeShellCommands/7f06614fcda00e6b
+++ b/internal/rule/testdata/fuzz/FuzzAnalyzeShellCommands/7f06614fcda00e6b
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("@(&''&&")


### PR DESCRIPTION
## Summary
- reject empty PowerShell call-operator targets, including forms with redirects
- retain the discovered input as fuzz corpus and add a PowerShell-specific regression test
- run all 15 existing fuzz targets in bounded CI

## Context
#29 found a real projection invariant failure and a CI coverage gap. This maintainer version scopes the fix to empty call-operator targets, so ordinary redirect-only projections remain supported. Thanks @sandiyochristan for finding it.

## Verification
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- golangci-lint v2.12.2: 0 issues
- `FuzzAnalyzeShellCommands`: 30 seconds, pass
