### PR TITLE
docs(hook): correct Cursor enforcement comment

### DIFF
--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -922,8 +922,8 @@ func EnforceEligible(agent, event string, lc Lifecycle) bool {
 		if lc == LifecycleCursorPreTool {
 			return true
 		}
-		// Retain control semantics for older/manual specialized configurations.
-		// Current installs use only the generic lifecycle above.
+		// Current installs use beforeReadFile; the shell and MCP names retain
+		// support for older or manually specialized configurations.
 		switch strings.ToLower(event) {
 		case "beforeshellexecution", "beforemcpexecution", "beforereadfile":
 			return true


### PR DESCRIPTION
## Summary
- correct the Cursor enforcement comment to reflect that current installs use `beforeReadFile`
- clarify that specialized shell and MCP names remain for older or manually configured hooks

No behavior changes.

## Verification
- `git diff --check`
- included in the combined release-candidate test, race, vet, lint, and build checks